### PR TITLE
Add MCP (Model Context Protocol) server implementation

### DIFF
--- a/packages/web/.wrangler/deploy/config.json
+++ b/packages/web/.wrangler/deploy/config.json
@@ -1,1 +1,1 @@
-{"configPath":"../../dist/otter_web/wrangler.json","auxiliaryWorkers":[]}
+{ "configPath": "../../dist/otter_web/wrangler.json", "auxiliaryWorkers": [] }

--- a/packages/web/src/routes/_app/new.bookmark.tsx
+++ b/packages/web/src/routes/_app/new.bookmark.tsx
@@ -22,8 +22,14 @@ export const Route = createFileRoute('/_app/new/bookmark')({
     const response = { tags }
     return response
   },
-  loaderDeps: ({ search }) => ({ url: search.url, bookmarklet: search.bookmarklet }),
-  validateSearch: (search: { url?: string; bookmarklet?: string }): { url?: string; bookmarklet?: string } => {
+  loaderDeps: ({ search }) => ({
+    url: search.url,
+    bookmarklet: search.bookmarklet,
+  }),
+  validateSearch: (search: {
+    url?: string
+    bookmarklet?: string
+  }): { url?: string; bookmarklet?: string } => {
     return {
       url: search.url,
       bookmarklet: search.bookmarklet,

--- a/packages/web/worker/hono.ts
+++ b/packages/web/worker/hono.ts
@@ -6,10 +6,10 @@ import { titleSystemPrompt } from './ai/title'
 import { getAllBookmarks } from './bookmarks/getAllBookmarks'
 import { getNewBookmark, postNewBookmark } from './bookmarks/new'
 import {
-	handleMcpDelete,
-	handleMcpGet,
-	handleMcpOptions,
-	handleMcpPost,
+  handleMcpDelete,
+  handleMcpGet,
+  handleMcpOptions,
+  handleMcpPost,
 } from './mcp/handler'
 import { getMedia } from './media/media'
 import { getMediaSearch } from './media/mediaSearch'
@@ -65,16 +65,16 @@ app.post('/ai/description', async (context) => {
   })
 })
 app.post('/mcp', async (c) => {
-	return await handleMcpPost(c)
+  return await handleMcpPost(c)
 })
 app.get('/mcp', (c) => {
-	return handleMcpGet(c)
+  return handleMcpGet(c)
 })
 app.delete('/mcp', (c) => {
-	return handleMcpDelete(c)
+  return handleMcpDelete(c)
 })
 app.options('/mcp', (c) => {
-	return handleMcpOptions(c)
+  return handleMcpOptions(c)
 })
 app.get('/rss', async (c) => {
   const feed = c.req.query('feed')

--- a/packages/web/worker/hono.ts
+++ b/packages/web/worker/hono.ts
@@ -5,6 +5,12 @@ import { generateResponse } from './ai/generateResponse'
 import { titleSystemPrompt } from './ai/title'
 import { getAllBookmarks } from './bookmarks/getAllBookmarks'
 import { getNewBookmark, postNewBookmark } from './bookmarks/new'
+import {
+	handleMcpDelete,
+	handleMcpGet,
+	handleMcpOptions,
+	handleMcpPost,
+} from './mcp/handler'
 import { getMedia } from './media/media'
 import { getMediaSearch } from './media/mediaSearch'
 import { feedToJson } from './rss/rss-to-json'
@@ -57,6 +63,18 @@ app.post('/ai/description', async (context) => {
     prompt,
     systemPrompt: descriptionSystemPrompt(title),
   })
+})
+app.post('/mcp', async (c) => {
+	return await handleMcpPost(c)
+})
+app.get('/mcp', (c) => {
+	return handleMcpGet(c)
+})
+app.delete('/mcp', (c) => {
+	return handleMcpDelete(c)
+})
+app.options('/mcp', (c) => {
+	return handleMcpOptions(c)
 })
 app.get('/rss', async (c) => {
   const feed = c.req.query('feed')

--- a/packages/web/worker/mcp/handler.ts
+++ b/packages/web/worker/mcp/handler.ts
@@ -5,23 +5,23 @@ import {
   INTERNAL_ERROR,
   INVALID_PARAMS,
   INVALID_REQUEST,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+  jsonRpcError,
+  jsonRpcSuccess,
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_NAME,
   MCP_SERVER_VERSION,
   METHOD_NOT_FOUND,
   PARSE_ERROR,
-  type JsonRpcRequest,
-  type JsonRpcResponse,
-  jsonRpcError,
-  jsonRpcSuccess,
   toolError,
 } from './types'
 
 const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers':
     'Content-Type, Accept, Authorization, Mcp-Session-Id',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Origin': '*',
 }
 
 const JSON_HEADERS = {
@@ -104,8 +104,8 @@ export const handleMcpPost = async (c: Context) => {
       return c.body(null, 204, CORS_HEADERS)
     }
     return new Response(JSON.stringify(responses), {
-      status: 200,
       headers: JSON_HEADERS,
+      status: 200,
     })
   }
 
@@ -190,8 +190,8 @@ async function dispatch(
   switch (method) {
     case 'initialize':
       return {
-        protocolVersion: MCP_PROTOCOL_VERSION,
         capabilities: { tools: {} },
+        protocolVersion: MCP_PROTOCOL_VERSION,
         serverInfo: {
           name: MCP_SERVER_NAME,
           version: MCP_SERVER_VERSION,
@@ -252,7 +252,7 @@ class JsonRpcException extends Error {
 
 function jsonResponse(c: Context, data: JsonRpcResponse) {
   return new Response(JSON.stringify(data), {
-    status: 200,
     headers: JSON_HEADERS,
+    status: 200,
   })
 }

--- a/packages/web/worker/mcp/handler.ts
+++ b/packages/web/worker/mcp/handler.ts
@@ -1,0 +1,249 @@
+import type { Context } from 'hono'
+import { createAuthenticatedClient } from '../supabase/client'
+import { toolDefinitions, toolHandlers } from './tools'
+import {
+	INTERNAL_ERROR,
+	INVALID_PARAMS,
+	INVALID_REQUEST,
+	MCP_PROTOCOL_VERSION,
+	MCP_SERVER_NAME,
+	MCP_SERVER_VERSION,
+	METHOD_NOT_FOUND,
+	PARSE_ERROR,
+	type JsonRpcRequest,
+	type JsonRpcResponse,
+	jsonRpcError,
+	jsonRpcSuccess,
+	toolError,
+} from './types'
+
+const CORS_HEADERS = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'POST, OPTIONS',
+	'Access-Control-Allow-Headers':
+		'Content-Type, Accept, Authorization, Mcp-Session-Id',
+}
+
+const JSON_HEADERS = {
+	...CORS_HEADERS,
+	'Content-Type': 'application/json',
+}
+
+/**
+ * OPTIONS /api/mcp — CORS preflight
+ */
+export const handleMcpOptions = (c: Context) => {
+	return c.body(null, 204, CORS_HEADERS)
+}
+
+/**
+ * GET /api/mcp — SSE not supported (stateless mode)
+ */
+export const handleMcpGet = (c: Context) => {
+	return c.text('SSE not supported. Use POST for JSON-RPC requests.', 405, CORS_HEADERS)
+}
+
+/**
+ * DELETE /api/mcp — No sessions to terminate (stateless mode)
+ */
+export const handleMcpDelete = (c: Context) => {
+	return c.text('Session management not supported (stateless server).', 405, CORS_HEADERS)
+}
+
+/**
+ * POST /api/mcp — Main MCP JSON-RPC handler
+ */
+export const handleMcpPost = async (c: Context) => {
+	// Validate Content-Type
+	const contentType = c.req.header('Content-Type')
+	if (!contentType?.includes('application/json')) {
+		return c.text('Content-Type must be application/json', 415, CORS_HEADERS)
+	}
+
+	// Authenticate
+	// @ts-expect-error - createAuthenticatedClient returns AuthenticatedClient | Response
+	const authResult = await createAuthenticatedClient(c.req)
+	if (authResult instanceof Response) {
+		return authResult
+	}
+	const { client, user } = authResult
+
+	// Parse JSON body
+	let body: unknown
+	try {
+		body = await c.req.json()
+	} catch {
+		return jsonResponse(
+			c,
+			jsonRpcError(null, PARSE_ERROR, 'Parse error: invalid JSON'),
+		)
+	}
+
+	// Handle batch requests
+	if (Array.isArray(body)) {
+		const responses: JsonRpcResponse[] = []
+		for (const msg of body) {
+			const result = await processMessage(msg as JsonRpcRequest, {
+				client,
+				userId: user.id,
+			})
+			if (result !== null) {
+				responses.push(result)
+			}
+		}
+		// If all messages were notifications, return 204
+		if (responses.length === 0) {
+			return c.body(null, 204, CORS_HEADERS)
+		}
+		return new Response(JSON.stringify(responses), {
+			status: 200,
+			headers: JSON_HEADERS,
+		})
+	}
+
+	// Handle single request
+	const result = await processMessage(body as JsonRpcRequest, {
+		client,
+		userId: user.id,
+	})
+	// Notification — no id, no response body
+	if (result === null) {
+		return c.body(null, 204, CORS_HEADERS)
+	}
+	return jsonResponse(c, result)
+}
+
+// --- Internal helpers ---
+
+interface ProcessContext {
+	client: ReturnType<typeof createAuthenticatedClient> extends Promise<
+		infer T
+	>
+		? T extends Response
+			? never
+			: T
+		: never
+	userId: string
+}
+
+// Narrow the type properly
+interface AuthedContext {
+	client: Awaited<ReturnType<typeof createAuthenticatedClient>> extends infer T
+		? T extends Response
+			? never
+			: T extends { client: infer C }
+				? C
+				: never
+		: never
+	userId: string
+}
+
+async function processMessage(
+	msg: JsonRpcRequest,
+	ctx: { client: unknown; userId: string },
+): Promise<JsonRpcResponse | null> {
+	// Validate basic structure
+	if (!msg || typeof msg !== 'object' || msg.jsonrpc !== '2.0' || !msg.method) {
+		// If there's no id, we can't send a response (it's a malformed notification)
+		if (!msg?.id) return null
+		return jsonRpcError(
+			msg?.id ?? null,
+			INVALID_REQUEST,
+			'Invalid Request: missing jsonrpc or method',
+		)
+	}
+
+	const id = msg.id ?? null
+	const isNotification = id === null || id === undefined
+
+	try {
+		const result = await dispatch(msg.method, msg.params, ctx)
+
+		// Notifications don't get responses
+		if (isNotification) return null
+
+		return jsonRpcSuccess(id, result)
+	} catch (err) {
+		if (isNotification) return null
+		if (err instanceof JsonRpcException) {
+			return jsonRpcError(id, err.code, err.message)
+		}
+		return jsonRpcError(
+			id,
+			INTERNAL_ERROR,
+			`Internal error: ${err instanceof Error ? err.message : 'unknown'}`,
+		)
+	}
+}
+
+async function dispatch(
+	method: string,
+	params: Record<string, unknown> | undefined,
+	ctx: { client: unknown; userId: string },
+): Promise<unknown> {
+	switch (method) {
+		case 'initialize':
+			return {
+				protocolVersion: MCP_PROTOCOL_VERSION,
+				capabilities: { tools: {} },
+				serverInfo: {
+					name: MCP_SERVER_NAME,
+					version: MCP_SERVER_VERSION,
+				},
+			}
+
+		case 'ping':
+			return {}
+
+		case 'notifications/initialized':
+			// No-op — processed but no result needed
+			return undefined
+
+		case 'tools/list':
+			return { tools: toolDefinitions }
+
+		case 'tools/call': {
+			const toolName = params?.name as string
+			if (!toolName) {
+				throw new JsonRpcException(INVALID_PARAMS, 'Missing tool name')
+			}
+			const handler = toolHandlers[toolName]
+			if (!handler) {
+				throw new JsonRpcException(
+					METHOD_NOT_FOUND,
+					`Unknown tool: ${toolName}`,
+				)
+			}
+			try {
+				return await handler(
+					(params?.arguments as Record<string, unknown>) || {},
+					// biome-ignore lint/suspicious/noExplicitAny: auth types are complex
+					{ client: ctx.client as any, userId: ctx.userId },
+				)
+			} catch (err) {
+				// Tool execution errors are returned as isError results, not JSON-RPC errors
+				return toolError(
+					`Tool execution failed: ${err instanceof Error ? err.message : String(err)}`,
+				)
+			}
+		}
+
+		default:
+			throw new JsonRpcException(METHOD_NOT_FOUND, `Method not found: ${method}`)
+	}
+}
+
+class JsonRpcException extends Error {
+	code: number
+	constructor(code: number, message: string) {
+		super(message)
+		this.code = code
+	}
+}
+
+function jsonResponse(c: Context, data: JsonRpcResponse) {
+	return new Response(JSON.stringify(data), {
+		status: 200,
+		headers: JSON_HEADERS,
+	})
+}

--- a/packages/web/worker/mcp/handler.ts
+++ b/packages/web/worker/mcp/handler.ts
@@ -2,248 +2,257 @@ import type { Context } from 'hono'
 import { createAuthenticatedClient } from '../supabase/client'
 import { toolDefinitions, toolHandlers } from './tools'
 import {
-	INTERNAL_ERROR,
-	INVALID_PARAMS,
-	INVALID_REQUEST,
-	MCP_PROTOCOL_VERSION,
-	MCP_SERVER_NAME,
-	MCP_SERVER_VERSION,
-	METHOD_NOT_FOUND,
-	PARSE_ERROR,
-	type JsonRpcRequest,
-	type JsonRpcResponse,
-	jsonRpcError,
-	jsonRpcSuccess,
-	toolError,
+  INTERNAL_ERROR,
+  INVALID_PARAMS,
+  INVALID_REQUEST,
+  MCP_PROTOCOL_VERSION,
+  MCP_SERVER_NAME,
+  MCP_SERVER_VERSION,
+  METHOD_NOT_FOUND,
+  PARSE_ERROR,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+  jsonRpcError,
+  jsonRpcSuccess,
+  toolError,
 } from './types'
 
 const CORS_HEADERS = {
-	'Access-Control-Allow-Origin': '*',
-	'Access-Control-Allow-Methods': 'POST, OPTIONS',
-	'Access-Control-Allow-Headers':
-		'Content-Type, Accept, Authorization, Mcp-Session-Id',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Accept, Authorization, Mcp-Session-Id',
 }
 
 const JSON_HEADERS = {
-	...CORS_HEADERS,
-	'Content-Type': 'application/json',
+  ...CORS_HEADERS,
+  'Content-Type': 'application/json',
 }
 
 /**
  * OPTIONS /api/mcp — CORS preflight
  */
 export const handleMcpOptions = (c: Context) => {
-	return c.body(null, 204, CORS_HEADERS)
+  return c.body(null, 204, CORS_HEADERS)
 }
 
 /**
  * GET /api/mcp — SSE not supported (stateless mode)
  */
 export const handleMcpGet = (c: Context) => {
-	return c.text('SSE not supported. Use POST for JSON-RPC requests.', 405, CORS_HEADERS)
+  return c.text(
+    'SSE not supported. Use POST for JSON-RPC requests.',
+    405,
+    CORS_HEADERS,
+  )
 }
 
 /**
  * DELETE /api/mcp — No sessions to terminate (stateless mode)
  */
 export const handleMcpDelete = (c: Context) => {
-	return c.text('Session management not supported (stateless server).', 405, CORS_HEADERS)
+  return c.text(
+    'Session management not supported (stateless server).',
+    405,
+    CORS_HEADERS,
+  )
 }
 
 /**
  * POST /api/mcp — Main MCP JSON-RPC handler
  */
 export const handleMcpPost = async (c: Context) => {
-	// Validate Content-Type
-	const contentType = c.req.header('Content-Type')
-	if (!contentType?.includes('application/json')) {
-		return c.text('Content-Type must be application/json', 415, CORS_HEADERS)
-	}
+  // Validate Content-Type
+  const contentType = c.req.header('Content-Type')
+  if (!contentType?.includes('application/json')) {
+    return c.text('Content-Type must be application/json', 415, CORS_HEADERS)
+  }
 
-	// Authenticate
-	// @ts-expect-error - createAuthenticatedClient returns AuthenticatedClient | Response
-	const authResult = await createAuthenticatedClient(c.req)
-	if (authResult instanceof Response) {
-		return authResult
-	}
-	const { client, user } = authResult
+  // Authenticate
+  // @ts-expect-error - createAuthenticatedClient returns AuthenticatedClient | Response
+  const authResult = await createAuthenticatedClient(c.req)
+  if (authResult instanceof Response) {
+    return authResult
+  }
+  const { client, user } = authResult
 
-	// Parse JSON body
-	let body: unknown
-	try {
-		body = await c.req.json()
-	} catch {
-		return jsonResponse(
-			c,
-			jsonRpcError(null, PARSE_ERROR, 'Parse error: invalid JSON'),
-		)
-	}
+  // Parse JSON body
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch {
+    return jsonResponse(
+      c,
+      jsonRpcError(null, PARSE_ERROR, 'Parse error: invalid JSON'),
+    )
+  }
 
-	// Handle batch requests
-	if (Array.isArray(body)) {
-		const responses: JsonRpcResponse[] = []
-		for (const msg of body) {
-			const result = await processMessage(msg as JsonRpcRequest, {
-				client,
-				userId: user.id,
-			})
-			if (result !== null) {
-				responses.push(result)
-			}
-		}
-		// If all messages were notifications, return 204
-		if (responses.length === 0) {
-			return c.body(null, 204, CORS_HEADERS)
-		}
-		return new Response(JSON.stringify(responses), {
-			status: 200,
-			headers: JSON_HEADERS,
-		})
-	}
+  // Handle batch requests
+  if (Array.isArray(body)) {
+    const responses: JsonRpcResponse[] = []
+    for (const msg of body) {
+      const result = await processMessage(msg as JsonRpcRequest, {
+        client,
+        userId: user.id,
+      })
+      if (result !== null) {
+        responses.push(result)
+      }
+    }
+    // If all messages were notifications, return 204
+    if (responses.length === 0) {
+      return c.body(null, 204, CORS_HEADERS)
+    }
+    return new Response(JSON.stringify(responses), {
+      status: 200,
+      headers: JSON_HEADERS,
+    })
+  }
 
-	// Handle single request
-	const result = await processMessage(body as JsonRpcRequest, {
-		client,
-		userId: user.id,
-	})
-	// Notification — no id, no response body
-	if (result === null) {
-		return c.body(null, 204, CORS_HEADERS)
-	}
-	return jsonResponse(c, result)
+  // Handle single request
+  const result = await processMessage(body as JsonRpcRequest, {
+    client,
+    userId: user.id,
+  })
+  // Notification — no id, no response body
+  if (result === null) {
+    return c.body(null, 204, CORS_HEADERS)
+  }
+  return jsonResponse(c, result)
 }
 
 // --- Internal helpers ---
 
 interface ProcessContext {
-	client: ReturnType<typeof createAuthenticatedClient> extends Promise<
-		infer T
-	>
-		? T extends Response
-			? never
-			: T
-		: never
-	userId: string
+  client: ReturnType<typeof createAuthenticatedClient> extends Promise<infer T>
+    ? T extends Response
+      ? never
+      : T
+    : never
+  userId: string
 }
 
 // Narrow the type properly
 interface AuthedContext {
-	client: Awaited<ReturnType<typeof createAuthenticatedClient>> extends infer T
-		? T extends Response
-			? never
-			: T extends { client: infer C }
-				? C
-				: never
-		: never
-	userId: string
+  client: Awaited<ReturnType<typeof createAuthenticatedClient>> extends infer T
+    ? T extends Response
+      ? never
+      : T extends { client: infer C }
+        ? C
+        : never
+    : never
+  userId: string
 }
 
 async function processMessage(
-	msg: JsonRpcRequest,
-	ctx: { client: unknown; userId: string },
+  msg: JsonRpcRequest,
+  ctx: { client: unknown; userId: string },
 ): Promise<JsonRpcResponse | null> {
-	// Validate basic structure
-	if (!msg || typeof msg !== 'object' || msg.jsonrpc !== '2.0' || !msg.method) {
-		// If there's no id, we can't send a response (it's a malformed notification)
-		if (!msg?.id) return null
-		return jsonRpcError(
-			msg?.id ?? null,
-			INVALID_REQUEST,
-			'Invalid Request: missing jsonrpc or method',
-		)
-	}
+  // Validate basic structure
+  if (!msg || typeof msg !== 'object' || msg.jsonrpc !== '2.0' || !msg.method) {
+    // If there's no id, we can't send a response (it's a malformed notification)
+    if (!msg?.id) return null
+    return jsonRpcError(
+      msg?.id ?? null,
+      INVALID_REQUEST,
+      'Invalid Request: missing jsonrpc or method',
+    )
+  }
 
-	const id = msg.id ?? null
-	const isNotification = id === null || id === undefined
+  const id = msg.id ?? null
+  const isNotification = id === null || id === undefined
 
-	try {
-		const result = await dispatch(msg.method, msg.params, ctx)
+  try {
+    const result = await dispatch(msg.method, msg.params, ctx)
 
-		// Notifications don't get responses
-		if (isNotification) return null
+    // Notifications don't get responses
+    if (isNotification) return null
 
-		return jsonRpcSuccess(id, result)
-	} catch (err) {
-		if (isNotification) return null
-		if (err instanceof JsonRpcException) {
-			return jsonRpcError(id, err.code, err.message)
-		}
-		return jsonRpcError(
-			id,
-			INTERNAL_ERROR,
-			`Internal error: ${err instanceof Error ? err.message : 'unknown'}`,
-		)
-	}
+    return jsonRpcSuccess(id, result)
+  } catch (err) {
+    if (isNotification) return null
+    if (err instanceof JsonRpcException) {
+      return jsonRpcError(id, err.code, err.message)
+    }
+    return jsonRpcError(
+      id,
+      INTERNAL_ERROR,
+      `Internal error: ${err instanceof Error ? err.message : 'unknown'}`,
+    )
+  }
 }
 
 async function dispatch(
-	method: string,
-	params: Record<string, unknown> | undefined,
-	ctx: { client: unknown; userId: string },
+  method: string,
+  params: Record<string, unknown> | undefined,
+  ctx: { client: unknown; userId: string },
 ): Promise<unknown> {
-	switch (method) {
-		case 'initialize':
-			return {
-				protocolVersion: MCP_PROTOCOL_VERSION,
-				capabilities: { tools: {} },
-				serverInfo: {
-					name: MCP_SERVER_NAME,
-					version: MCP_SERVER_VERSION,
-				},
-			}
+  switch (method) {
+    case 'initialize':
+      return {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: {
+          name: MCP_SERVER_NAME,
+          version: MCP_SERVER_VERSION,
+        },
+      }
 
-		case 'ping':
-			return {}
+    case 'ping':
+      return {}
 
-		case 'notifications/initialized':
-			// No-op — processed but no result needed
-			return undefined
+    case 'notifications/initialized':
+      // No-op — processed but no result needed
+      return undefined
 
-		case 'tools/list':
-			return { tools: toolDefinitions }
+    case 'tools/list':
+      return { tools: toolDefinitions }
 
-		case 'tools/call': {
-			const toolName = params?.name as string
-			if (!toolName) {
-				throw new JsonRpcException(INVALID_PARAMS, 'Missing tool name')
-			}
-			const handler = toolHandlers[toolName]
-			if (!handler) {
-				throw new JsonRpcException(
-					METHOD_NOT_FOUND,
-					`Unknown tool: ${toolName}`,
-				)
-			}
-			try {
-				return await handler(
-					(params?.arguments as Record<string, unknown>) || {},
-					// biome-ignore lint/suspicious/noExplicitAny: auth types are complex
-					{ client: ctx.client as any, userId: ctx.userId },
-				)
-			} catch (err) {
-				// Tool execution errors are returned as isError results, not JSON-RPC errors
-				return toolError(
-					`Tool execution failed: ${err instanceof Error ? err.message : String(err)}`,
-				)
-			}
-		}
+    case 'tools/call': {
+      const toolName = params?.name as string
+      if (!toolName) {
+        throw new JsonRpcException(INVALID_PARAMS, 'Missing tool name')
+      }
+      const handler = toolHandlers[toolName]
+      if (!handler) {
+        throw new JsonRpcException(
+          METHOD_NOT_FOUND,
+          `Unknown tool: ${toolName}`,
+        )
+      }
+      try {
+        return await handler(
+          (params?.arguments as Record<string, unknown>) || {},
+          // biome-ignore lint/suspicious/noExplicitAny: auth types are complex
+          { client: ctx.client as any, userId: ctx.userId },
+        )
+      } catch (err) {
+        // Tool execution errors are returned as isError results, not JSON-RPC errors
+        return toolError(
+          `Tool execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+    }
 
-		default:
-			throw new JsonRpcException(METHOD_NOT_FOUND, `Method not found: ${method}`)
-	}
+    default:
+      throw new JsonRpcException(
+        METHOD_NOT_FOUND,
+        `Method not found: ${method}`,
+      )
+  }
 }
 
 class JsonRpcException extends Error {
-	code: number
-	constructor(code: number, message: string) {
-		super(message)
-		this.code = code
-	}
+  code: number
+  constructor(code: number, message: string) {
+    super(message)
+    this.code = code
+  }
 }
 
 function jsonResponse(c: Context, data: JsonRpcResponse) {
-	return new Response(JSON.stringify(data), {
-		status: 200,
-		headers: JSON_HEADERS,
-	})
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: JSON_HEADERS,
+  })
 }

--- a/packages/web/worker/mcp/tools.ts
+++ b/packages/web/worker/mcp/tools.ts
@@ -1,0 +1,534 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { TidyURL } from 'tidy-url'
+import type { Database } from '@/types/supabase'
+import { getBookmarks } from '@/utils/fetching/bookmarks'
+import { getDbMetadata } from '@/utils/fetching/meta'
+import { getSearchBookmarks } from '@/utils/fetching/search'
+import { matchTagsSource } from '@/utils/matchTags'
+import { linkType } from '../scraper/link-type'
+import Scraper from '../scraper/scraper'
+import { scraperRules } from '../scraper/scraper-rules'
+import {
+	type CallToolResult,
+	type McpToolDefinition,
+	toolError,
+	toolResult,
+} from './types'
+
+type Bookmark = Database['public']['Tables']['bookmarks']['Row']
+
+const BOOKMARK_TYPES = [
+	'link',
+	'video',
+	'audio',
+	'recipe',
+	'image',
+	'document',
+	'article',
+	'game',
+	'book',
+	'event',
+	'product',
+	'note',
+	'file',
+	'place',
+] as const
+
+const MAX_LIMIT = 50
+const MAX_RANDOM = 10
+
+const typeEnumSchema = {
+	type: 'string',
+	enum: BOOKMARK_TYPES,
+} as const
+
+interface ToolContext {
+	client: SupabaseClient<Database>
+	userId: string
+}
+
+type ToolHandler = (
+	args: Record<string, unknown>,
+	ctx: ToolContext,
+) => Promise<CallToolResult>
+
+interface McpTool {
+	definition: McpToolDefinition
+	handler: ToolHandler
+}
+
+// --- Formatting helpers ---
+
+function formatBookmark(b: Bookmark, index?: number): string {
+	const prefix = index !== undefined ? `${index}. ` : ''
+	const lines: string[] = []
+	lines.push(`${prefix}${b.title || '(untitled)'}`)
+	if (b.url) lines.push(`   ${b.url}`)
+	if (b.description) lines.push(`   ${b.description}`)
+	if (b.note) lines.push(`   Note: ${b.note}`)
+	const meta: string[] = []
+	if (b.tags?.length) meta.push(`Tags: ${b.tags.join(', ')}`)
+	if (b.star) meta.push('★ Starred')
+	if (b.public) meta.push('Public')
+	if (b.type) meta.push(`Type: ${b.type}`)
+	meta.push(`Created: ${b.created_at.split('T')[0]}`)
+	if (meta.length) lines.push(`   ${meta.join(' | ')}`)
+	lines.push(`   ID: ${b.id}`)
+	return lines.join('\n')
+}
+
+function formatBookmarkList(
+	bookmarks: Bookmark[],
+	count: number | null,
+): string {
+	if (!bookmarks.length) return 'No bookmarks found.'
+	const header = `Found ${count ?? bookmarks.length} bookmark${(count ?? bookmarks.length) !== 1 ? 's' : ''}:\n`
+	return (
+		header + bookmarks.map((b, i) => formatBookmark(b, i + 1)).join('\n\n')
+	)
+}
+
+function clampLimit(val: unknown): number {
+	const n = Number(val) || 19
+	return Math.min(Math.max(1, n), MAX_LIMIT)
+}
+
+// --- Tool definitions and handlers ---
+
+const searchBookmarks: McpTool = {
+	definition: {
+		name: 'search_bookmarks',
+		description:
+			'Search bookmarks by text across title, URL, description, note, and tags.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				query: { type: 'string', description: 'Search term' },
+				type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
+				status: {
+					type: 'string',
+					enum: ['active', 'inactive'],
+					description: 'Filter by status (default: active)',
+				},
+				star: { type: 'boolean', description: 'Only starred bookmarks' },
+				tag: { type: 'string', description: 'Filter by tag' },
+				limit: {
+					type: 'number',
+					description: 'Max results (default: 19, max: 50)',
+				},
+			},
+			required: ['query'],
+		},
+	},
+	handler: async (args, ctx) => {
+		const { data, count, error } = await getSearchBookmarks({
+			searchTerm: args.query as string,
+			params: {
+				type: args.type as string | undefined,
+				status: (args.status as 'active' | 'inactive') || undefined,
+				star: args.star as boolean | undefined,
+				tag: args.tag as string | undefined,
+				limit: clampLimit(args.limit),
+			},
+			supabaseClient: ctx.client,
+			userId: ctx.userId,
+		})
+		if (error) return toolError(`Search failed: ${error.message}`)
+		return toolResult(formatBookmarkList(data || [], count))
+	},
+}
+
+const listBookmarks: McpTool = {
+	definition: {
+		name: 'list_bookmarks',
+		description:
+			'List bookmarks with filters (no text search). Use search_bookmarks for text search.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
+				status: {
+					type: 'string',
+					enum: ['active', 'inactive'],
+					description: 'Filter by status (default: active)',
+				},
+				star: { type: 'boolean', description: 'Only starred bookmarks' },
+				public: { type: 'boolean', description: 'Only public bookmarks' },
+				tag: { type: 'string', description: 'Filter by tag' },
+				top: {
+					type: 'boolean',
+					description: 'Sort by click count (most clicked first)',
+				},
+				limit: {
+					type: 'number',
+					description: 'Max results (default: 19, max: 50)',
+				},
+				offset: { type: 'number', description: 'Pagination offset (default: 0)' },
+			},
+		},
+	},
+	handler: async (args, ctx) => {
+		try {
+			const { data, count } = await getBookmarks(
+				{
+					type: args.type as string | undefined,
+					status: (args.status as 'active' | 'inactive') || undefined,
+					star: args.star as boolean | undefined,
+					public: args.public as boolean | undefined,
+					tag: args.tag as string | undefined,
+					top: args.top as boolean | undefined,
+					limit: clampLimit(args.limit),
+					offset: Number(args.offset) || 0,
+				},
+				ctx.client,
+				ctx.userId,
+			)
+			return toolResult(formatBookmarkList(data || [], count))
+		} catch (err) {
+			return toolError(
+				`List failed: ${err instanceof Error ? err.message : String(err)}`,
+			)
+		}
+	},
+}
+
+const listTags: McpTool = {
+	definition: {
+		name: 'list_tags',
+		description: 'List all tags with usage counts.',
+		inputSchema: { type: 'object', properties: {} },
+	},
+	handler: async (_args, ctx) => {
+		const { data, error } = await ctx.client
+			.from('tags_count')
+			.select('*')
+			.order('count', { ascending: false })
+		if (error) return toolError(`Failed to list tags: ${error.message}`)
+		if (!data?.length) return toolResult('No tags found.')
+		const lines = data.map(
+			(t) => `${t.tag} (${t.count ?? 0})`,
+		)
+		return toolResult(`${data.length} tags:\n${lines.join('\n')}`)
+	},
+}
+
+const getStats: McpTool = {
+	definition: {
+		name: 'get_stats',
+		description:
+			'Get database overview: total bookmarks, starred, public, trash counts, type breakdown, and collections.',
+		inputSchema: { type: 'object', properties: {} },
+	},
+	handler: async (_args, ctx) => {
+		try {
+			const meta = await getDbMetadata(ctx.client)
+			const lines = [
+				`Bookmarks: ${meta.all} total, ${meta.stars} starred, ${meta.public} public, ${meta.trash} in trash, ${meta.top} with clicks`,
+				'',
+				'Types:',
+				...(meta.types || []).map(
+					(t) => `  ${t.type}: ${t.count}`,
+				),
+				'',
+				`Tags: ${meta.tags?.length ?? 0} unique tags`,
+				'',
+				'Collections:',
+				...(meta.collections || []).map(
+					(c) =>
+						`  ${c.collection}: ${c.bookmark_count} bookmarks`,
+				),
+			]
+			return toolResult(lines.join('\n'))
+		} catch (err) {
+			return toolError(
+				`Stats failed: ${err instanceof Error ? err.message : String(err)}`,
+			)
+		}
+	},
+}
+
+const randomBookmark: McpTool = {
+	definition: {
+		name: 'random_bookmark',
+		description: 'Get random bookmark(s) matching optional filters.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				count: {
+					type: 'number',
+					description: 'Number of random bookmarks (default: 1, max: 10)',
+				},
+				type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
+				tag: { type: 'string', description: 'Filter by tag' },
+			},
+		},
+	},
+	handler: async (args, ctx) => {
+		const requestedCount = Math.min(
+			Math.max(1, Number(args.count) || 1),
+			MAX_RANDOM,
+		)
+
+		// Build a base query to get count
+		let countQuery = ctx.client
+			.from('bookmarks')
+			.select('*', { count: 'exact', head: true })
+			.eq('user', ctx.userId)
+			.eq('status', 'active')
+		if (args.type) countQuery = countQuery.eq('type', args.type as string)
+		if (args.tag)
+			countQuery = countQuery.filter('tags', 'cs', `{${args.tag}}`)
+
+		const { count, error: countError } = await countQuery
+		if (countError) return toolError(`Failed to count: ${countError.message}`)
+		if (!count || count === 0) return toolResult('No matching bookmarks found.')
+
+		// Pick random offsets and fetch individual bookmarks
+		const results: Bookmark[] = []
+		const usedOffsets = new Set<number>()
+		const maxAttempts = Math.min(requestedCount, count)
+
+		for (let i = 0; i < maxAttempts; i++) {
+			let offset: number
+			do {
+				offset = Math.floor(Math.random() * count)
+			} while (usedOffsets.has(offset) && usedOffsets.size < count)
+			usedOffsets.add(offset)
+
+			let query = ctx.client
+				.from('bookmarks')
+				.select('*')
+				.eq('user', ctx.userId)
+				.eq('status', 'active')
+			if (args.type) query = query.eq('type', args.type as string)
+			if (args.tag) query = query.filter('tags', 'cs', `{${args.tag}}`)
+			const { data } = await query
+				.order('created_at', { ascending: false })
+				.range(offset, offset)
+				.limit(1)
+			if (data?.[0]) results.push(data[0])
+		}
+
+		if (!results.length) return toolResult('No bookmarks found.')
+		return toolResult(formatBookmarkList(results, results.length))
+	},
+}
+
+const createBookmark: McpTool = {
+	definition: {
+		name: 'create_bookmark',
+		description:
+			'Create a new bookmark. By default, automatically fetches title, description, tags, and type from the URL.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				url: { type: 'string', description: 'Bookmark URL' },
+				scrape: {
+					type: 'boolean',
+					description:
+						'Auto-fetch metadata from URL (default: true). Set false to skip.',
+				},
+				title: {
+					type: 'string',
+					description: 'Title (overrides scraped title)',
+				},
+				description: {
+					type: 'string',
+					description: 'Description (overrides scraped description)',
+				},
+				note: { type: 'string', description: 'Personal note' },
+				tags: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'Tags (merged with auto-detected tags)',
+				},
+				type: {
+					...typeEnumSchema,
+					description: 'Bookmark type (overrides detected type)',
+				},
+				star: { type: 'boolean', description: 'Star the bookmark' },
+				public: { type: 'boolean', description: 'Make publicly visible' },
+			},
+			required: ['url'],
+		},
+	},
+	handler: async (args, ctx) => {
+		const url = args.url as string
+		const shouldScrape = args.scrape !== false
+
+		let scrapedData: Record<string, unknown> = {}
+		let autoTags: string[] = []
+
+		if (shouldScrape) {
+			try {
+				const scraper = new Scraper()
+				await scraper.fetch(url)
+				const metadata = await scraper.getMetadata(scraperRules)
+				const unshortenedUrl = scraper.response.url
+				const cleanedUrl = TidyURL.clean(unshortenedUrl || url)
+
+				scrapedData = {
+					title: metadata.title || null,
+					description: metadata.description || null,
+					image: metadata.image || null,
+					feed: metadata.feeds || null,
+					url: cleanedUrl.url || unshortenedUrl || url,
+					type: linkType(url, false),
+				}
+
+				// Auto-detect tags based on scraped metadata
+				const dbMeta = await getDbMetadata(ctx.client)
+				autoTags = matchTagsSource(
+					{
+						title: (metadata.title as string) || undefined,
+						description: (metadata.description as string) || undefined,
+					},
+					dbMeta.tags,
+				)
+			} catch {
+				// Scraping failed — continue with manual data only
+				scrapedData = { url }
+			}
+		}
+
+		const userTags = (args.tags as string[]) || []
+		const mergedTags = [...new Set([...autoTags, ...userTags])]
+
+		const insertData = {
+			url: (scrapedData.url as string) || url,
+			title: (args.title as string) ?? (scrapedData.title as string | null),
+			description:
+				(args.description as string) ??
+				(scrapedData.description as string | null),
+			image: scrapedData.image as string | null,
+			feed: scrapedData.feed as string | null,
+			note: (args.note as string) || null,
+			tags: mergedTags.length ? mergedTags : null,
+			type:
+				(args.type as string) ??
+				(scrapedData.type as string | null) ??
+				null,
+			star: (args.star as boolean) || false,
+			public: (args.public as boolean) || false,
+			user: ctx.userId,
+		}
+
+		const { data, error } = await ctx.client
+			.from('bookmarks')
+			.insert([insertData])
+			.select()
+
+		if (error) return toolError(`Create failed: ${error.message}`)
+		if (!data?.[0]) return toolError('Create succeeded but no data returned.')
+		return toolResult(
+			`Bookmark created:\n\n${formatBookmark(data[0])}`,
+		)
+	},
+}
+
+const updateBookmark: McpTool = {
+	definition: {
+		name: 'update_bookmark',
+		description: 'Update an existing bookmark by ID.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Bookmark UUID' },
+				title: { type: 'string', description: 'New title' },
+				description: { type: 'string', description: 'New description' },
+				note: { type: 'string', description: 'New note' },
+				tags: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'New tags (replaces existing)',
+				},
+				type: { ...typeEnumSchema, description: 'New type' },
+				star: { type: 'boolean', description: 'Star/unstar' },
+				public: { type: 'boolean', description: 'Make public/private' },
+				status: {
+					type: 'string',
+					enum: ['active', 'inactive'],
+					description: 'Set to inactive to trash',
+				},
+			},
+			required: ['id'],
+		},
+	},
+	handler: async (args, ctx) => {
+		const { id, ...updates } = args
+		// Filter out undefined values
+		const updateData: Record<string, unknown> = {}
+		for (const [key, value] of Object.entries(updates)) {
+			if (value !== undefined) updateData[key] = value
+		}
+		updateData.modified_at = new Date().toISOString()
+
+		if (Object.keys(updateData).length <= 1) {
+			return toolError('No fields to update. Provide at least one field to change.')
+		}
+
+		const { data, error } = await ctx.client
+			.from('bookmarks')
+			.update(updateData)
+			.eq('id', id as string)
+			.eq('user', ctx.userId)
+			.select()
+
+		if (error) return toolError(`Update failed: ${error.message}`)
+		if (!data?.length) return toolError('Bookmark not found or access denied.')
+		return toolResult(
+			`Bookmark updated:\n\n${formatBookmark(data[0])}`,
+		)
+	},
+}
+
+const deleteBookmark: McpTool = {
+	definition: {
+		name: 'delete_bookmark',
+		description:
+			'Soft-delete a bookmark by moving it to trash (sets status to inactive).',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Bookmark UUID' },
+			},
+			required: ['id'],
+		},
+	},
+	handler: async (args, ctx) => {
+		const { data, error } = await ctx.client
+			.from('bookmarks')
+			.update({
+				status: 'inactive' as const,
+				modified_at: new Date().toISOString(),
+			})
+			.eq('id', args.id as string)
+			.eq('user', ctx.userId)
+			.select()
+
+		if (error) return toolError(`Delete failed: ${error.message}`)
+		if (!data?.length) return toolError('Bookmark not found or access denied.')
+		return toolResult(
+			`Bookmark moved to trash:\n\n${formatBookmark(data[0])}`,
+		)
+	},
+}
+
+// --- Exports ---
+
+export const tools: McpTool[] = [
+	searchBookmarks,
+	listBookmarks,
+	listTags,
+	getStats,
+	randomBookmark,
+	createBookmark,
+	updateBookmark,
+	deleteBookmark,
+]
+
+export const toolDefinitions: McpToolDefinition[] = tools.map((t) => t.definition)
+
+export const toolHandlers: Record<string, ToolHandler> = Object.fromEntries(
+	tools.map((t) => [t.definition.name, t.handler]),
+)

--- a/packages/web/worker/mcp/tools.ts
+++ b/packages/web/worker/mcp/tools.ts
@@ -9,526 +9,517 @@ import { linkType } from '../scraper/link-type'
 import Scraper from '../scraper/scraper'
 import { scraperRules } from '../scraper/scraper-rules'
 import {
-	type CallToolResult,
-	type McpToolDefinition,
-	toolError,
-	toolResult,
+  type CallToolResult,
+  type McpToolDefinition,
+  toolError,
+  toolResult,
 } from './types'
 
 type Bookmark = Database['public']['Tables']['bookmarks']['Row']
 
 const BOOKMARK_TYPES = [
-	'link',
-	'video',
-	'audio',
-	'recipe',
-	'image',
-	'document',
-	'article',
-	'game',
-	'book',
-	'event',
-	'product',
-	'note',
-	'file',
-	'place',
+  'link',
+  'video',
+  'audio',
+  'recipe',
+  'image',
+  'document',
+  'article',
+  'game',
+  'book',
+  'event',
+  'product',
+  'note',
+  'file',
+  'place',
 ] as const
 
 const MAX_LIMIT = 50
 const MAX_RANDOM = 10
 
 const typeEnumSchema = {
-	type: 'string',
-	enum: BOOKMARK_TYPES,
+  enum: BOOKMARK_TYPES,
+  type: 'string',
 } as const
 
 interface ToolContext {
-	client: SupabaseClient<Database>
-	userId: string
+  client: SupabaseClient<Database>
+  userId: string
 }
 
 type ToolHandler = (
-	args: Record<string, unknown>,
-	ctx: ToolContext,
+  args: Record<string, unknown>,
+  ctx: ToolContext,
 ) => Promise<CallToolResult>
 
 interface McpTool {
-	definition: McpToolDefinition
-	handler: ToolHandler
+  definition: McpToolDefinition
+  handler: ToolHandler
 }
 
 // --- Formatting helpers ---
 
 function formatBookmark(b: Bookmark, index?: number): string {
-	const prefix = index !== undefined ? `${index}. ` : ''
-	const lines: string[] = []
-	lines.push(`${prefix}${b.title || '(untitled)'}`)
-	if (b.url) lines.push(`   ${b.url}`)
-	if (b.description) lines.push(`   ${b.description}`)
-	if (b.note) lines.push(`   Note: ${b.note}`)
-	const meta: string[] = []
-	if (b.tags?.length) meta.push(`Tags: ${b.tags.join(', ')}`)
-	if (b.star) meta.push('★ Starred')
-	if (b.public) meta.push('Public')
-	if (b.type) meta.push(`Type: ${b.type}`)
-	meta.push(`Created: ${b.created_at.split('T')[0]}`)
-	if (meta.length) lines.push(`   ${meta.join(' | ')}`)
-	lines.push(`   ID: ${b.id}`)
-	return lines.join('\n')
+  const prefix = index !== undefined ? `${index}. ` : ''
+  const lines: string[] = []
+  lines.push(`${prefix}${b.title || '(untitled)'}`)
+  if (b.url) lines.push(`   ${b.url}`)
+  if (b.description) lines.push(`   ${b.description}`)
+  if (b.note) lines.push(`   Note: ${b.note}`)
+  const meta: string[] = []
+  if (b.tags?.length) meta.push(`Tags: ${b.tags.join(', ')}`)
+  if (b.star) meta.push('★ Starred')
+  if (b.public) meta.push('Public')
+  if (b.type) meta.push(`Type: ${b.type}`)
+  meta.push(`Created: ${b.created_at.split('T')[0]}`)
+  if (meta.length) lines.push(`   ${meta.join(' | ')}`)
+  lines.push(`   ID: ${b.id}`)
+  return lines.join('\n')
 }
 
 function formatBookmarkList(
-	bookmarks: Bookmark[],
-	count: number | null,
+  bookmarks: Bookmark[],
+  count: number | null,
 ): string {
-	if (!bookmarks.length) return 'No bookmarks found.'
-	const header = `Found ${count ?? bookmarks.length} bookmark${(count ?? bookmarks.length) !== 1 ? 's' : ''}:\n`
-	return (
-		header + bookmarks.map((b, i) => formatBookmark(b, i + 1)).join('\n\n')
-	)
+  if (!bookmarks.length) return 'No bookmarks found.'
+  const header = `Found ${count ?? bookmarks.length} bookmark${(count ?? bookmarks.length) !== 1 ? 's' : ''}:\n`
+  return header + bookmarks.map((b, i) => formatBookmark(b, i + 1)).join('\n\n')
 }
 
 function clampLimit(val: unknown): number {
-	const n = Number(val) || 19
-	return Math.min(Math.max(1, n), MAX_LIMIT)
+  const n = Number(val) || 19
+  return Math.min(Math.max(1, n), MAX_LIMIT)
 }
 
 // --- Tool definitions and handlers ---
 
 const searchBookmarks: McpTool = {
-	definition: {
-		name: 'search_bookmarks',
-		description:
-			'Search bookmarks by text across title, URL, description, note, and tags.',
-		inputSchema: {
-			type: 'object',
-			properties: {
-				query: { type: 'string', description: 'Search term' },
-				type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
-				status: {
-					type: 'string',
-					enum: ['active', 'inactive'],
-					description: 'Filter by status (default: active)',
-				},
-				star: { type: 'boolean', description: 'Only starred bookmarks' },
-				tag: { type: 'string', description: 'Filter by tag' },
-				limit: {
-					type: 'number',
-					description: 'Max results (default: 19, max: 50)',
-				},
-			},
-			required: ['query'],
-		},
-	},
-	handler: async (args, ctx) => {
-		const { data, count, error } = await getSearchBookmarks({
-			searchTerm: args.query as string,
-			params: {
-				type: args.type as string | undefined,
-				status: (args.status as 'active' | 'inactive') || undefined,
-				star: args.star as boolean | undefined,
-				tag: args.tag as string | undefined,
-				limit: clampLimit(args.limit),
-			},
-			supabaseClient: ctx.client,
-			userId: ctx.userId,
-		})
-		if (error) return toolError(`Search failed: ${error.message}`)
-		return toolResult(formatBookmarkList(data || [], count))
-	},
+  definition: {
+    description:
+      'Search bookmarks by text across title, URL, description, note, and tags.',
+    inputSchema: {
+      properties: {
+        limit: {
+          description: 'Max results (default: 19, max: 50)',
+          type: 'number',
+        },
+        query: { description: 'Search term', type: 'string' },
+        star: { description: 'Only starred bookmarks', type: 'boolean' },
+        status: {
+          description: 'Filter by status (default: active)',
+          enum: ['active', 'inactive'],
+          type: 'string',
+        },
+        tag: { description: 'Filter by tag', type: 'string' },
+        type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
+      },
+      required: ['query'],
+      type: 'object',
+    },
+    name: 'search_bookmarks',
+  },
+  handler: async (args, ctx) => {
+    const { data, count, error } = await getSearchBookmarks({
+      params: {
+        limit: clampLimit(args.limit),
+        star: args.star as boolean | undefined,
+        status: (args.status as 'active' | 'inactive') || undefined,
+        tag: args.tag as string | undefined,
+        type: args.type as string | undefined,
+      },
+      searchTerm: args.query as string,
+      supabaseClient: ctx.client,
+      userId: ctx.userId,
+    })
+    if (error) return toolError(`Search failed: ${error.message}`)
+    return toolResult(formatBookmarkList(data || [], count))
+  },
 }
 
 const listBookmarks: McpTool = {
-	definition: {
-		name: 'list_bookmarks',
-		description:
-			'List bookmarks with filters (no text search). Use search_bookmarks for text search.',
-		inputSchema: {
-			type: 'object',
-			properties: {
-				type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
-				status: {
-					type: 'string',
-					enum: ['active', 'inactive'],
-					description: 'Filter by status (default: active)',
-				},
-				star: { type: 'boolean', description: 'Only starred bookmarks' },
-				public: { type: 'boolean', description: 'Only public bookmarks' },
-				tag: { type: 'string', description: 'Filter by tag' },
-				top: {
-					type: 'boolean',
-					description: 'Sort by click count (most clicked first)',
-				},
-				limit: {
-					type: 'number',
-					description: 'Max results (default: 19, max: 50)',
-				},
-				offset: { type: 'number', description: 'Pagination offset (default: 0)' },
-			},
-		},
-	},
-	handler: async (args, ctx) => {
-		try {
-			const { data, count } = await getBookmarks(
-				{
-					type: args.type as string | undefined,
-					status: (args.status as 'active' | 'inactive') || undefined,
-					star: args.star as boolean | undefined,
-					public: args.public as boolean | undefined,
-					tag: args.tag as string | undefined,
-					top: args.top as boolean | undefined,
-					limit: clampLimit(args.limit),
-					offset: Number(args.offset) || 0,
-				},
-				ctx.client,
-				ctx.userId,
-			)
-			return toolResult(formatBookmarkList(data || [], count))
-		} catch (err) {
-			return toolError(
-				`List failed: ${err instanceof Error ? err.message : String(err)}`,
-			)
-		}
-	},
+  definition: {
+    description:
+      'List bookmarks with filters (no text search). Use search_bookmarks for text search.',
+    inputSchema: {
+      properties: {
+        limit: {
+          description: 'Max results (default: 19, max: 50)',
+          type: 'number',
+        },
+        offset: {
+          description: 'Pagination offset (default: 0)',
+          type: 'number',
+        },
+        public: { description: 'Only public bookmarks', type: 'boolean' },
+        star: { description: 'Only starred bookmarks', type: 'boolean' },
+        status: {
+          description: 'Filter by status (default: active)',
+          enum: ['active', 'inactive'],
+          type: 'string',
+        },
+        tag: { description: 'Filter by tag', type: 'string' },
+        top: {
+          description: 'Sort by click count (most clicked first)',
+          type: 'boolean',
+        },
+        type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
+      },
+      type: 'object',
+    },
+    name: 'list_bookmarks',
+  },
+  handler: async (args, ctx) => {
+    try {
+      const { data, count } = await getBookmarks(
+        {
+          limit: clampLimit(args.limit),
+          offset: Number(args.offset) || 0,
+          public: args.public as boolean | undefined,
+          star: args.star as boolean | undefined,
+          status: (args.status as 'active' | 'inactive') || undefined,
+          tag: args.tag as string | undefined,
+          top: args.top as boolean | undefined,
+          type: args.type as string | undefined,
+        },
+        ctx.client,
+        ctx.userId,
+      )
+      return toolResult(formatBookmarkList(data || [], count))
+    } catch (err) {
+      return toolError(
+        `List failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  },
 }
 
 const listTags: McpTool = {
-	definition: {
-		name: 'list_tags',
-		description: 'List all tags with usage counts.',
-		inputSchema: { type: 'object', properties: {} },
-	},
-	handler: async (_args, ctx) => {
-		const { data, error } = await ctx.client
-			.from('tags_count')
-			.select('*')
-			.order('count', { ascending: false })
-		if (error) return toolError(`Failed to list tags: ${error.message}`)
-		if (!data?.length) return toolResult('No tags found.')
-		const lines = data.map(
-			(t) => `${t.tag} (${t.count ?? 0})`,
-		)
-		return toolResult(`${data.length} tags:\n${lines.join('\n')}`)
-	},
+  definition: {
+    description: 'List all tags with usage counts.',
+    inputSchema: { properties: {}, type: 'object' },
+    name: 'list_tags',
+  },
+  handler: async (_args, ctx) => {
+    const { data, error } = await ctx.client
+      .from('tags_count')
+      .select('*')
+      .order('count', { ascending: false })
+    if (error) return toolError(`Failed to list tags: ${error.message}`)
+    if (!data?.length) return toolResult('No tags found.')
+    const lines = data.map((t) => `${t.tag} (${t.count ?? 0})`)
+    return toolResult(`${data.length} tags:\n${lines.join('\n')}`)
+  },
 }
 
 const getStats: McpTool = {
-	definition: {
-		name: 'get_stats',
-		description:
-			'Get database overview: total bookmarks, starred, public, trash counts, type breakdown, and collections.',
-		inputSchema: { type: 'object', properties: {} },
-	},
-	handler: async (_args, ctx) => {
-		try {
-			const meta = await getDbMetadata(ctx.client)
-			const lines = [
-				`Bookmarks: ${meta.all} total, ${meta.stars} starred, ${meta.public} public, ${meta.trash} in trash, ${meta.top} with clicks`,
-				'',
-				'Types:',
-				...(meta.types || []).map(
-					(t) => `  ${t.type}: ${t.count}`,
-				),
-				'',
-				`Tags: ${meta.tags?.length ?? 0} unique tags`,
-				'',
-				'Collections:',
-				...(meta.collections || []).map(
-					(c) =>
-						`  ${c.collection}: ${c.bookmark_count} bookmarks`,
-				),
-			]
-			return toolResult(lines.join('\n'))
-		} catch (err) {
-			return toolError(
-				`Stats failed: ${err instanceof Error ? err.message : String(err)}`,
-			)
-		}
-	},
+  definition: {
+    description:
+      'Get database overview: total bookmarks, starred, public, trash counts, type breakdown, and collections.',
+    inputSchema: { properties: {}, type: 'object' },
+    name: 'get_stats',
+  },
+  handler: async (_args, ctx) => {
+    try {
+      const meta = await getDbMetadata(ctx.client)
+      const lines = [
+        `Bookmarks: ${meta.all} total, ${meta.stars} starred, ${meta.public} public, ${meta.trash} in trash, ${meta.top} with clicks`,
+        '',
+        'Types:',
+        ...(meta.types || []).map((t) => `  ${t.type}: ${t.count}`),
+        '',
+        `Tags: ${meta.tags?.length ?? 0} unique tags`,
+        '',
+        'Collections:',
+        ...(meta.collections || []).map(
+          (c) => `  ${c.collection}: ${c.bookmark_count} bookmarks`,
+        ),
+      ]
+      return toolResult(lines.join('\n'))
+    } catch (err) {
+      return toolError(
+        `Stats failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  },
 }
 
 const randomBookmark: McpTool = {
-	definition: {
-		name: 'random_bookmark',
-		description: 'Get random bookmark(s) matching optional filters.',
-		inputSchema: {
-			type: 'object',
-			properties: {
-				count: {
-					type: 'number',
-					description: 'Number of random bookmarks (default: 1, max: 10)',
-				},
-				type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
-				tag: { type: 'string', description: 'Filter by tag' },
-			},
-		},
-	},
-	handler: async (args, ctx) => {
-		const requestedCount = Math.min(
-			Math.max(1, Number(args.count) || 1),
-			MAX_RANDOM,
-		)
+  definition: {
+    description: 'Get random bookmark(s) matching optional filters.',
+    inputSchema: {
+      properties: {
+        count: {
+          description: 'Number of random bookmarks (default: 1, max: 10)',
+          type: 'number',
+        },
+        tag: { description: 'Filter by tag', type: 'string' },
+        type: { ...typeEnumSchema, description: 'Filter by bookmark type' },
+      },
+      type: 'object',
+    },
+    name: 'random_bookmark',
+  },
+  handler: async (args, ctx) => {
+    const requestedCount = Math.min(
+      Math.max(1, Number(args.count) || 1),
+      MAX_RANDOM,
+    )
 
-		// Build a base query to get count
-		let countQuery = ctx.client
-			.from('bookmarks')
-			.select('*', { count: 'exact', head: true })
-			.eq('user', ctx.userId)
-			.eq('status', 'active')
-		if (args.type) countQuery = countQuery.eq('type', args.type as string)
-		if (args.tag)
-			countQuery = countQuery.filter('tags', 'cs', `{${args.tag}}`)
+    // Build a base query to get count
+    let countQuery = ctx.client
+      .from('bookmarks')
+      .select('*', { count: 'exact', head: true })
+      .eq('user', ctx.userId)
+      .eq('status', 'active')
+    if (args.type) countQuery = countQuery.eq('type', args.type as string)
+    if (args.tag) countQuery = countQuery.filter('tags', 'cs', `{${args.tag}}`)
 
-		const { count, error: countError } = await countQuery
-		if (countError) return toolError(`Failed to count: ${countError.message}`)
-		if (!count || count === 0) return toolResult('No matching bookmarks found.')
+    const { count, error: countError } = await countQuery
+    if (countError) return toolError(`Failed to count: ${countError.message}`)
+    if (!count || count === 0) return toolResult('No matching bookmarks found.')
 
-		// Pick random offsets and fetch individual bookmarks
-		const results: Bookmark[] = []
-		const usedOffsets = new Set<number>()
-		const maxAttempts = Math.min(requestedCount, count)
+    // Pick random offsets and fetch individual bookmarks
+    const results: Bookmark[] = []
+    const usedOffsets = new Set<number>()
+    const maxAttempts = Math.min(requestedCount, count)
 
-		for (let i = 0; i < maxAttempts; i++) {
-			let offset: number
-			do {
-				offset = Math.floor(Math.random() * count)
-			} while (usedOffsets.has(offset) && usedOffsets.size < count)
-			usedOffsets.add(offset)
+    for (let i = 0; i < maxAttempts; i++) {
+      let offset: number
+      do {
+        offset = Math.floor(Math.random() * count)
+      } while (usedOffsets.has(offset) && usedOffsets.size < count)
+      usedOffsets.add(offset)
 
-			let query = ctx.client
-				.from('bookmarks')
-				.select('*')
-				.eq('user', ctx.userId)
-				.eq('status', 'active')
-			if (args.type) query = query.eq('type', args.type as string)
-			if (args.tag) query = query.filter('tags', 'cs', `{${args.tag}}`)
-			const { data } = await query
-				.order('created_at', { ascending: false })
-				.range(offset, offset)
-				.limit(1)
-			if (data?.[0]) results.push(data[0])
-		}
+      let query = ctx.client
+        .from('bookmarks')
+        .select('*')
+        .eq('user', ctx.userId)
+        .eq('status', 'active')
+      if (args.type) query = query.eq('type', args.type as string)
+      if (args.tag) query = query.filter('tags', 'cs', `{${args.tag}}`)
+      const { data } = await query
+        .order('created_at', { ascending: false })
+        .range(offset, offset)
+        .limit(1)
+      if (data?.[0]) results.push(data[0])
+    }
 
-		if (!results.length) return toolResult('No bookmarks found.')
-		return toolResult(formatBookmarkList(results, results.length))
-	},
+    if (!results.length) return toolResult('No bookmarks found.')
+    return toolResult(formatBookmarkList(results, results.length))
+  },
 }
 
 const createBookmark: McpTool = {
-	definition: {
-		name: 'create_bookmark',
-		description:
-			'Create a new bookmark. By default, automatically fetches title, description, tags, and type from the URL.',
-		inputSchema: {
-			type: 'object',
-			properties: {
-				url: { type: 'string', description: 'Bookmark URL' },
-				scrape: {
-					type: 'boolean',
-					description:
-						'Auto-fetch metadata from URL (default: true). Set false to skip.',
-				},
-				title: {
-					type: 'string',
-					description: 'Title (overrides scraped title)',
-				},
-				description: {
-					type: 'string',
-					description: 'Description (overrides scraped description)',
-				},
-				note: { type: 'string', description: 'Personal note' },
-				tags: {
-					type: 'array',
-					items: { type: 'string' },
-					description: 'Tags (merged with auto-detected tags)',
-				},
-				type: {
-					...typeEnumSchema,
-					description: 'Bookmark type (overrides detected type)',
-				},
-				star: { type: 'boolean', description: 'Star the bookmark' },
-				public: { type: 'boolean', description: 'Make publicly visible' },
-			},
-			required: ['url'],
-		},
-	},
-	handler: async (args, ctx) => {
-		const url = args.url as string
-		const shouldScrape = args.scrape !== false
+  definition: {
+    description:
+      'Create a new bookmark. By default, automatically fetches title, description, tags, and type from the URL.',
+    inputSchema: {
+      properties: {
+        description: {
+          description: 'Description (overrides scraped description)',
+          type: 'string',
+        },
+        note: { description: 'Personal note', type: 'string' },
+        public: { description: 'Make publicly visible', type: 'boolean' },
+        scrape: {
+          description:
+            'Auto-fetch metadata from URL (default: true). Set false to skip.',
+          type: 'boolean',
+        },
+        star: { description: 'Star the bookmark', type: 'boolean' },
+        tags: {
+          description: 'Tags (merged with auto-detected tags)',
+          items: { type: 'string' },
+          type: 'array',
+        },
+        title: {
+          description: 'Title (overrides scraped title)',
+          type: 'string',
+        },
+        type: {
+          ...typeEnumSchema,
+          description: 'Bookmark type (overrides detected type)',
+        },
+        url: { description: 'Bookmark URL', type: 'string' },
+      },
+      required: ['url'],
+      type: 'object',
+    },
+    name: 'create_bookmark',
+  },
+  handler: async (args, ctx) => {
+    const url = args.url as string
+    const shouldScrape = args.scrape !== false
 
-		let scrapedData: Record<string, unknown> = {}
-		let autoTags: string[] = []
+    let scrapedData: Record<string, unknown> = {}
+    let autoTags: string[] = []
 
-		if (shouldScrape) {
-			try {
-				const scraper = new Scraper()
-				await scraper.fetch(url)
-				const metadata = await scraper.getMetadata(scraperRules)
-				const unshortenedUrl = scraper.response.url
-				const cleanedUrl = TidyURL.clean(unshortenedUrl || url)
+    if (shouldScrape) {
+      try {
+        const scraper = new Scraper()
+        await scraper.fetch(url)
+        const metadata = await scraper.getMetadata(scraperRules)
+        const unshortenedUrl = scraper.response.url
+        const cleanedUrl = TidyURL.clean(unshortenedUrl || url)
 
-				scrapedData = {
-					title: metadata.title || null,
-					description: metadata.description || null,
-					image: metadata.image || null,
-					feed: metadata.feeds || null,
-					url: cleanedUrl.url || unshortenedUrl || url,
-					type: linkType(url, false),
-				}
+        scrapedData = {
+          description: metadata.description || null,
+          feed: metadata.feeds || null,
+          image: metadata.image || null,
+          title: metadata.title || null,
+          type: linkType(url, false),
+          url: cleanedUrl.url || unshortenedUrl || url,
+        }
 
-				// Auto-detect tags based on scraped metadata
-				const dbMeta = await getDbMetadata(ctx.client)
-				autoTags = matchTagsSource(
-					{
-						title: (metadata.title as string) || undefined,
-						description: (metadata.description as string) || undefined,
-					},
-					dbMeta.tags,
-				)
-			} catch {
-				// Scraping failed — continue with manual data only
-				scrapedData = { url }
-			}
-		}
+        // Auto-detect tags based on scraped metadata
+        const dbMeta = await getDbMetadata(ctx.client)
+        autoTags = matchTagsSource(
+          {
+            description: (metadata.description as string) || undefined,
+            title: (metadata.title as string) || undefined,
+          },
+          dbMeta.tags,
+        )
+      } catch {
+        // Scraping failed — continue with manual data only
+        scrapedData = { url }
+      }
+    }
 
-		const userTags = (args.tags as string[]) || []
-		const mergedTags = [...new Set([...autoTags, ...userTags])]
+    const userTags = (args.tags as string[]) || []
+    const mergedTags = [...new Set([...autoTags, ...userTags])]
 
-		const insertData = {
-			url: (scrapedData.url as string) || url,
-			title: (args.title as string) ?? (scrapedData.title as string | null),
-			description:
-				(args.description as string) ??
-				(scrapedData.description as string | null),
-			image: scrapedData.image as string | null,
-			feed: scrapedData.feed as string | null,
-			note: (args.note as string) || null,
-			tags: mergedTags.length ? mergedTags : null,
-			type:
-				(args.type as string) ??
-				(scrapedData.type as string | null) ??
-				null,
-			star: (args.star as boolean) || false,
-			public: (args.public as boolean) || false,
-			user: ctx.userId,
-		}
+    const insertData = {
+      description:
+        (args.description as string) ??
+        (scrapedData.description as string | null),
+      feed: scrapedData.feed as string | null,
+      image: scrapedData.image as string | null,
+      note: (args.note as string) || null,
+      public: (args.public as boolean) || false,
+      star: (args.star as boolean) || false,
+      tags: mergedTags.length ? mergedTags : null,
+      title: (args.title as string) ?? (scrapedData.title as string | null),
+      type:
+        (args.type as string) ?? (scrapedData.type as string | null) ?? null,
+      url: (scrapedData.url as string) || url,
+      user: ctx.userId,
+    }
 
-		const { data, error } = await ctx.client
-			.from('bookmarks')
-			.insert([insertData])
-			.select()
+    const { data, error } = await ctx.client
+      .from('bookmarks')
+      .insert([insertData])
+      .select()
 
-		if (error) return toolError(`Create failed: ${error.message}`)
-		if (!data?.[0]) return toolError('Create succeeded but no data returned.')
-		return toolResult(
-			`Bookmark created:\n\n${formatBookmark(data[0])}`,
-		)
-	},
+    if (error) return toolError(`Create failed: ${error.message}`)
+    if (!data?.[0]) return toolError('Create succeeded but no data returned.')
+    return toolResult(`Bookmark created:\n\n${formatBookmark(data[0])}`)
+  },
 }
 
 const updateBookmark: McpTool = {
-	definition: {
-		name: 'update_bookmark',
-		description: 'Update an existing bookmark by ID.',
-		inputSchema: {
-			type: 'object',
-			properties: {
-				id: { type: 'string', description: 'Bookmark UUID' },
-				title: { type: 'string', description: 'New title' },
-				description: { type: 'string', description: 'New description' },
-				note: { type: 'string', description: 'New note' },
-				tags: {
-					type: 'array',
-					items: { type: 'string' },
-					description: 'New tags (replaces existing)',
-				},
-				type: { ...typeEnumSchema, description: 'New type' },
-				star: { type: 'boolean', description: 'Star/unstar' },
-				public: { type: 'boolean', description: 'Make public/private' },
-				status: {
-					type: 'string',
-					enum: ['active', 'inactive'],
-					description: 'Set to inactive to trash',
-				},
-			},
-			required: ['id'],
-		},
-	},
-	handler: async (args, ctx) => {
-		const { id, ...updates } = args
-		// Filter out undefined values
-		const updateData: Record<string, unknown> = {}
-		for (const [key, value] of Object.entries(updates)) {
-			if (value !== undefined) updateData[key] = value
-		}
-		updateData.modified_at = new Date().toISOString()
+  definition: {
+    description: 'Update an existing bookmark by ID.',
+    inputSchema: {
+      properties: {
+        description: { description: 'New description', type: 'string' },
+        id: { description: 'Bookmark UUID', type: 'string' },
+        note: { description: 'New note', type: 'string' },
+        public: { description: 'Make public/private', type: 'boolean' },
+        star: { description: 'Star/unstar', type: 'boolean' },
+        status: {
+          description: 'Set to inactive to trash',
+          enum: ['active', 'inactive'],
+          type: 'string',
+        },
+        tags: {
+          description: 'New tags (replaces existing)',
+          items: { type: 'string' },
+          type: 'array',
+        },
+        title: { description: 'New title', type: 'string' },
+        type: { ...typeEnumSchema, description: 'New type' },
+      },
+      required: ['id'],
+      type: 'object',
+    },
+    name: 'update_bookmark',
+  },
+  handler: async (args, ctx) => {
+    const { id, ...updates } = args
+    // Filter out undefined values
+    const updateData: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(updates)) {
+      if (value !== undefined) updateData[key] = value
+    }
+    updateData.modified_at = new Date().toISOString()
 
-		if (Object.keys(updateData).length <= 1) {
-			return toolError('No fields to update. Provide at least one field to change.')
-		}
+    if (Object.keys(updateData).length <= 1) {
+      return toolError(
+        'No fields to update. Provide at least one field to change.',
+      )
+    }
 
-		const { data, error } = await ctx.client
-			.from('bookmarks')
-			.update(updateData)
-			.eq('id', id as string)
-			.eq('user', ctx.userId)
-			.select()
+    const { data, error } = await ctx.client
+      .from('bookmarks')
+      .update(updateData)
+      .eq('id', id as string)
+      .eq('user', ctx.userId)
+      .select()
 
-		if (error) return toolError(`Update failed: ${error.message}`)
-		if (!data?.length) return toolError('Bookmark not found or access denied.')
-		return toolResult(
-			`Bookmark updated:\n\n${formatBookmark(data[0])}`,
-		)
-	},
+    if (error) return toolError(`Update failed: ${error.message}`)
+    if (!data?.length) return toolError('Bookmark not found or access denied.')
+    return toolResult(`Bookmark updated:\n\n${formatBookmark(data[0])}`)
+  },
 }
 
 const deleteBookmark: McpTool = {
-	definition: {
-		name: 'delete_bookmark',
-		description:
-			'Soft-delete a bookmark by moving it to trash (sets status to inactive).',
-		inputSchema: {
-			type: 'object',
-			properties: {
-				id: { type: 'string', description: 'Bookmark UUID' },
-			},
-			required: ['id'],
-		},
-	},
-	handler: async (args, ctx) => {
-		const { data, error } = await ctx.client
-			.from('bookmarks')
-			.update({
-				status: 'inactive' as const,
-				modified_at: new Date().toISOString(),
-			})
-			.eq('id', args.id as string)
-			.eq('user', ctx.userId)
-			.select()
+  definition: {
+    description:
+      'Soft-delete a bookmark by moving it to trash (sets status to inactive).',
+    inputSchema: {
+      properties: {
+        id: { description: 'Bookmark UUID', type: 'string' },
+      },
+      required: ['id'],
+      type: 'object',
+    },
+    name: 'delete_bookmark',
+  },
+  handler: async (args, ctx) => {
+    const { data, error } = await ctx.client
+      .from('bookmarks')
+      .update({
+        modified_at: new Date().toISOString(),
+        status: 'inactive' as const,
+      })
+      .eq('id', args.id as string)
+      .eq('user', ctx.userId)
+      .select()
 
-		if (error) return toolError(`Delete failed: ${error.message}`)
-		if (!data?.length) return toolError('Bookmark not found or access denied.')
-		return toolResult(
-			`Bookmark moved to trash:\n\n${formatBookmark(data[0])}`,
-		)
-	},
+    if (error) return toolError(`Delete failed: ${error.message}`)
+    if (!data?.length) return toolError('Bookmark not found or access denied.')
+    return toolResult(`Bookmark moved to trash:\n\n${formatBookmark(data[0])}`)
+  },
 }
 
 // --- Exports ---
 
 export const tools: McpTool[] = [
-	searchBookmarks,
-	listBookmarks,
-	listTags,
-	getStats,
-	randomBookmark,
-	createBookmark,
-	updateBookmark,
-	deleteBookmark,
+  searchBookmarks,
+  listBookmarks,
+  listTags,
+  getStats,
+  randomBookmark,
+  createBookmark,
+  updateBookmark,
+  deleteBookmark,
 ]
 
-export const toolDefinitions: McpToolDefinition[] = tools.map((t) => t.definition)
+export const toolDefinitions: McpToolDefinition[] = tools.map(
+  (t) => t.definition,
+)
 
 export const toolHandlers: Record<string, ToolHandler> = Object.fromEntries(
-	tools.map((t) => [t.definition.name, t.handler]),
+  tools.map((t) => [t.definition.name, t.handler]),
 )

--- a/packages/web/worker/mcp/types.ts
+++ b/packages/web/worker/mcp/types.ts
@@ -1,23 +1,23 @@
 // JSON-RPC 2.0 types for MCP Streamable HTTP transport
 
 export interface JsonRpcRequest {
-	jsonrpc: '2.0'
-	method: string
-	params?: Record<string, unknown>
-	id?: string | number
+  jsonrpc: '2.0'
+  method: string
+  params?: Record<string, unknown>
+  id?: string | number
 }
 
 export interface JsonRpcResponse {
-	jsonrpc: '2.0'
-	id: string | number | null
-	result?: unknown
-	error?: JsonRpcError
+  jsonrpc: '2.0'
+  id: string | number | null
+  result?: unknown
+  error?: JsonRpcError
 }
 
 export interface JsonRpcError {
-	code: number
-	message: string
-	data?: unknown
+  code: number
+  message: string
+  data?: unknown
 }
 
 // Standard JSON-RPC 2.0 error codes
@@ -34,55 +34,55 @@ export const MCP_SERVER_VERSION = '1.0.0'
 
 // MCP tool result types
 export interface TextContent {
-	type: 'text'
-	text: string
+  type: 'text'
+  text: string
 }
 
 export interface CallToolResult {
-	content: TextContent[]
-	isError?: boolean
+  content: TextContent[]
+  isError?: boolean
 }
 
 // MCP tool definition
 export interface McpToolDefinition {
-	name: string
-	description: string
-	inputSchema: {
-		type: 'object'
-		properties: Record<string, unknown>
-		required?: string[]
-	}
+  name: string
+  description: string
+  inputSchema: {
+    type: 'object'
+    properties: Record<string, unknown>
+    required?: string[]
+  }
 }
 
 // Helper to create a JSON-RPC success response
 export const jsonRpcSuccess = (
-	id: string | number | null,
-	result: unknown,
+  id: string | number | null,
+  result: unknown,
 ): JsonRpcResponse => ({
-	jsonrpc: '2.0',
-	id,
-	result,
+  jsonrpc: '2.0',
+  id,
+  result,
 })
 
 // Helper to create a JSON-RPC error response
 export const jsonRpcError = (
-	id: string | number | null,
-	code: number,
-	message: string,
-	data?: unknown,
+  id: string | number | null,
+  code: number,
+  message: string,
+  data?: unknown,
 ): JsonRpcResponse => ({
-	jsonrpc: '2.0',
-	id,
-	error: { code, message, ...(data !== undefined && { data }) },
+  jsonrpc: '2.0',
+  id,
+  error: { code, message, ...(data !== undefined && { data }) },
 })
 
 // Helper to create a successful tool result
 export const toolResult = (text: string): CallToolResult => ({
-	content: [{ type: 'text', text }],
+  content: [{ type: 'text', text }],
 })
 
 // Helper to create an error tool result
 export const toolError = (text: string): CallToolResult => ({
-	content: [{ type: 'text', text }],
-	isError: true,
+  content: [{ type: 'text', text }],
+  isError: true,
 })

--- a/packages/web/worker/mcp/types.ts
+++ b/packages/web/worker/mcp/types.ts
@@ -1,0 +1,88 @@
+// JSON-RPC 2.0 types for MCP Streamable HTTP transport
+
+export interface JsonRpcRequest {
+	jsonrpc: '2.0'
+	method: string
+	params?: Record<string, unknown>
+	id?: string | number
+}
+
+export interface JsonRpcResponse {
+	jsonrpc: '2.0'
+	id: string | number | null
+	result?: unknown
+	error?: JsonRpcError
+}
+
+export interface JsonRpcError {
+	code: number
+	message: string
+	data?: unknown
+}
+
+// Standard JSON-RPC 2.0 error codes
+export const PARSE_ERROR = -32700
+export const INVALID_REQUEST = -32600
+export const METHOD_NOT_FOUND = -32601
+export const INVALID_PARAMS = -32602
+export const INTERNAL_ERROR = -32603
+
+// MCP protocol constants
+export const MCP_PROTOCOL_VERSION = '2025-03-26'
+export const MCP_SERVER_NAME = 'otter'
+export const MCP_SERVER_VERSION = '1.0.0'
+
+// MCP tool result types
+export interface TextContent {
+	type: 'text'
+	text: string
+}
+
+export interface CallToolResult {
+	content: TextContent[]
+	isError?: boolean
+}
+
+// MCP tool definition
+export interface McpToolDefinition {
+	name: string
+	description: string
+	inputSchema: {
+		type: 'object'
+		properties: Record<string, unknown>
+		required?: string[]
+	}
+}
+
+// Helper to create a JSON-RPC success response
+export const jsonRpcSuccess = (
+	id: string | number | null,
+	result: unknown,
+): JsonRpcResponse => ({
+	jsonrpc: '2.0',
+	id,
+	result,
+})
+
+// Helper to create a JSON-RPC error response
+export const jsonRpcError = (
+	id: string | number | null,
+	code: number,
+	message: string,
+	data?: unknown,
+): JsonRpcResponse => ({
+	jsonrpc: '2.0',
+	id,
+	error: { code, message, ...(data !== undefined && { data }) },
+})
+
+// Helper to create a successful tool result
+export const toolResult = (text: string): CallToolResult => ({
+	content: [{ type: 'text', text }],
+})
+
+// Helper to create an error tool result
+export const toolError = (text: string): CallToolResult => ({
+	content: [{ type: 'text', text }],
+	isError: true,
+})


### PR DESCRIPTION
## Summary
Implements a Model Context Protocol (MCP) server that exposes bookmark management functionality via JSON-RPC 2.0 over HTTP. This enables AI assistants and other MCP clients to interact with the bookmark system programmatically.

## Key Changes
- **New MCP Tools Module** (`packages/web/worker/mcp/tools.ts`): Defines 8 bookmark management tools with full JSON-RPC schema definitions:
  - `search_bookmarks` — Full-text search across bookmarks
  - `list_bookmarks` — List bookmarks with filtering and pagination
  - `list_tags` — List all tags with usage counts
  - `get_stats` — Database overview and statistics
  - `random_bookmark` — Get random bookmarks with optional filters
  - `create_bookmark` — Create new bookmarks with automatic metadata scraping
  - `update_bookmark` — Update existing bookmarks
  - `delete_bookmark` — Soft-delete bookmarks to trash

- **MCP Handler** (`packages/web/worker/mcp/handler.ts`): Implements JSON-RPC 2.0 request processing with:
  - Authentication via existing Supabase client
  - Batch request support
  - Proper error handling with standard JSON-RPC error codes
  - CORS support for cross-origin requests
  - Stateless server design (no session management)

- **Type Definitions** (`packages/web/worker/mcp/types.ts`): Complete JSON-RPC 2.0 and MCP protocol types including:
  - Request/response structures
  - Standard error codes
  - Tool result formats
  - Helper functions for creating responses

- **Hono Router Integration** (`packages/web/worker/hono.ts`): Wired MCP endpoints:
  - `POST /mcp` — Main JSON-RPC request handler
  - `GET /mcp` — Returns 405 (SSE not supported)
  - `DELETE /mcp` — Returns 405 (no session management)
  - `OPTIONS /mcp` — CORS preflight support

## Notable Implementation Details
- Automatic metadata scraping for new bookmarks using existing Scraper and tag-matching utilities
- Bookmark formatting helpers for consistent, readable output across all tools
- Input validation with clamped limits (max 50 results, max 10 random bookmarks)
- Proper handling of notifications (requests without `id` field) per JSON-RPC spec
- User isolation via authenticated Supabase client context
- Soft-delete pattern (status = 'inactive') for bookmark deletion