### PR TITLE
Add bookmark confirmation page after successful item creation

### DIFF
--- a/packages/web/src/components/BookmarkForm.tsx
+++ b/packages/web/src/components/BookmarkForm.tsx
@@ -177,6 +177,8 @@ export const BookmarkForm = ({
       toast.message('Uh oh! Something went wrong.', {
         description: 'There was a problem with your request. Please try again.',
       })
+    } finally {
+      setFormSubmitting(false)
     }
   }
 

--- a/packages/web/src/components/BookmarkForm.tsx
+++ b/packages/web/src/components/BookmarkForm.tsx
@@ -30,7 +30,11 @@ import {
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import useSound from 'use-sound'
-import { CONTENT, DEFAULT_BOOKMARK_FORM_URL_PLACEHOLDER } from '../constants'
+import {
+  CONTENT,
+  DEFAULT_BOOKMARK_FORM_URL_PLACEHOLDER,
+  ROUTE_NEW_BOOKMARK_CONFIRMATION,
+} from '../constants'
 import { useToggle } from '../hooks/useToggle'
 import type { MetadataResponse } from '../types/api'
 import type { Bookmark, BookmarkFormValues } from '../types/db'
@@ -134,18 +138,24 @@ export const BookmarkForm = ({
 
     try {
       if (isNew) {
-        const { data } = await supabase
+        const { data: insertedBookmark, error } = await supabase
           .from('bookmarks')
           .insert([{ ...formData }], {
             defaultToNull: true,
           })
           .select('id')
+          .single()
+        if (error) {
+          throw error
+        }
         playAdd()
-        if (isBookmarklet && data?.[0]?.id) {
+        if (isBookmarklet && insertedBookmark?.id) {
           navigate({
-            params: { id: data[0].id },
-            search: { bookmarklet: 'true' },
-            to: '/new/bookmark/confirmation',
+            search: {
+              bookmarklet: isBookmarklet ? 'true' : undefined,
+              id: insertedBookmark.id,
+            },
+            to: ROUTE_NEW_BOOKMARK_CONFIRMATION,
           })
         } else {
           toast.success('Item added')
@@ -242,7 +252,7 @@ export const BookmarkForm = ({
           url_input: url.hostname,
         })
         setPossibleMatchingItems(data as Bookmark[])
-      } catch (err) {
+      } catch {
         setPossibleMatchingItems(null)
       }
     },

--- a/packages/web/src/components/BookmarkForm.tsx
+++ b/packages/web/src/components/BookmarkForm.tsx
@@ -141,14 +141,14 @@ export const BookmarkForm = ({
           })
           .select('id')
         playAdd()
-        toast.success('Item added')
         if (isBookmarklet && data?.[0]?.id) {
           navigate({
             params: { id: data[0].id },
             search: { bookmarklet: 'true' },
-            to: '/bookmark/$id',
+            to: '/new/bookmark/confirmation',
           })
         } else {
+          toast.success('Item added')
           navigate({ to: '/feed' })
         }
       } else {

--- a/packages/web/src/constants.ts
+++ b/packages/web/src/constants.ts
@@ -79,6 +79,7 @@ export const ROUTE_HOME = ROUTE_DASHBOARD
 export const ROUTE_FEED = '/feed'
 export const ROUTE_SIGNIN = '/signin'
 export const ROUTE_NEW_BOOKMARK = '/new/bookmark'
+export const ROUTE_NEW_BOOKMARK_CONFIRMATION = '/new/bookmark/confirmation'
 export const ROUTE_STARS = '/stars'
 export const ROUTE_PUBLIC = '/public'
 export const ROUTE_STATS = '/top'

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AppOauthConsentRouteImport } from './routes/_app/oauth/consent
 import { Route as AppNewBookmarkRouteImport } from './routes/_app/new.bookmark'
 import { Route as AppCollectionCollectionRouteImport } from './routes/_app/collection.$collection'
 import { Route as AppBookmarkIdRouteImport } from './routes/_app/bookmark.$id'
+import { Route as AppNewBookmarkConfirmationRouteImport } from './routes/_app/new.bookmark.confirmation'
 import { Route as AppBookmarkIdEditRouteImport } from './routes/_app/bookmark.$id.edit'
 
 const TermsRoute = TermsRouteImport.update({
@@ -165,6 +166,12 @@ const AppBookmarkIdRoute = AppBookmarkIdRouteImport.update({
   path: '/bookmark/$id',
   getParentRoute: () => AppRouteRoute,
 } as any)
+const AppNewBookmarkConfirmationRoute =
+  AppNewBookmarkConfirmationRouteImport.update({
+    id: '/confirmation',
+    path: '/confirmation',
+    getParentRoute: () => AppNewBookmarkRoute,
+  } as any)
 const AppBookmarkIdEditRoute = AppBookmarkIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -188,7 +195,7 @@ export interface FileRoutesByFullPath {
   '/tweets': typeof AppTweetsRoute
   '/bookmark/$id': typeof AppBookmarkIdRouteWithChildren
   '/collection/$collection': typeof AppCollectionCollectionRoute
-  '/new/bookmark': typeof AppNewBookmarkRoute
+  '/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/oauth/consent': typeof AppOauthConsentRoute
   '/settings/account': typeof AppSettingsAccountRoute
   '/settings/integrations': typeof AppSettingsIntegrationsRoute
@@ -197,6 +204,7 @@ export interface FileRoutesByFullPath {
   '/type/$type': typeof AppTypeTypeRoute
   '/signin/': typeof PublicSigninIndexRoute
   '/bookmark/$id/edit': typeof AppBookmarkIdEditRoute
+  '/new/bookmark/confirmation': typeof AppNewBookmarkConfirmationRoute
 }
 export interface FileRoutesByTo {
   '/': typeof PublicIndexRoute
@@ -215,7 +223,7 @@ export interface FileRoutesByTo {
   '/tweets': typeof AppTweetsRoute
   '/bookmark/$id': typeof AppBookmarkIdRouteWithChildren
   '/collection/$collection': typeof AppCollectionCollectionRoute
-  '/new/bookmark': typeof AppNewBookmarkRoute
+  '/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/oauth/consent': typeof AppOauthConsentRoute
   '/settings/account': typeof AppSettingsAccountRoute
   '/settings/integrations': typeof AppSettingsIntegrationsRoute
@@ -224,6 +232,7 @@ export interface FileRoutesByTo {
   '/type/$type': typeof AppTypeTypeRoute
   '/signin': typeof PublicSigninIndexRoute
   '/bookmark/$id/edit': typeof AppBookmarkIdEditRoute
+  '/new/bookmark/confirmation': typeof AppNewBookmarkConfirmationRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -245,7 +254,7 @@ export interface FileRoutesById {
   '/_public/': typeof PublicIndexRoute
   '/_app/bookmark/$id': typeof AppBookmarkIdRouteWithChildren
   '/_app/collection/$collection': typeof AppCollectionCollectionRoute
-  '/_app/new/bookmark': typeof AppNewBookmarkRoute
+  '/_app/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/_app/oauth/consent': typeof AppOauthConsentRoute
   '/_app/settings/account': typeof AppSettingsAccountRoute
   '/_app/settings/integrations': typeof AppSettingsIntegrationsRoute
@@ -254,6 +263,7 @@ export interface FileRoutesById {
   '/_app/type/$type': typeof AppTypeTypeRoute
   '/_public/signin/': typeof PublicSigninIndexRoute
   '/_app/bookmark/$id/edit': typeof AppBookmarkIdEditRoute
+  '/_app/new/bookmark/confirmation': typeof AppNewBookmarkConfirmationRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -283,6 +293,7 @@ export interface FileRouteTypes {
     | '/type/$type'
     | '/signin/'
     | '/bookmark/$id/edit'
+    | '/new/bookmark/confirmation'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -310,6 +321,7 @@ export interface FileRouteTypes {
     | '/type/$type'
     | '/signin'
     | '/bookmark/$id/edit'
+    | '/new/bookmark/confirmation'
   id:
     | '__root__'
     | '/_app'
@@ -339,6 +351,7 @@ export interface FileRouteTypes {
     | '/_app/type/$type'
     | '/_public/signin/'
     | '/_app/bookmark/$id/edit'
+    | '/_app/new/bookmark/confirmation'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -532,6 +545,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppBookmarkIdRouteImport
       parentRoute: typeof AppRouteRoute
     }
+    '/_app/new/bookmark/confirmation': {
+      id: '/_app/new/bookmark/confirmation'
+      path: '/confirmation'
+      fullPath: '/new/bookmark/confirmation'
+      preLoaderRoute: typeof AppNewBookmarkConfirmationRouteImport
+      parentRoute: typeof AppNewBookmarkRoute
+    }
     '/_app/bookmark/$id/edit': {
       id: '/_app/bookmark/$id/edit'
       path: '/edit'
@@ -569,6 +589,18 @@ const AppBookmarkIdRouteWithChildren = AppBookmarkIdRoute._addFileChildren(
   AppBookmarkIdRouteChildren,
 )
 
+interface AppNewBookmarkRouteChildren {
+  AppNewBookmarkConfirmationRoute: typeof AppNewBookmarkConfirmationRoute
+}
+
+const AppNewBookmarkRouteChildren: AppNewBookmarkRouteChildren = {
+  AppNewBookmarkConfirmationRoute: AppNewBookmarkConfirmationRoute,
+}
+
+const AppNewBookmarkRouteWithChildren = AppNewBookmarkRoute._addFileChildren(
+  AppNewBookmarkRouteChildren,
+)
+
 interface AppRouteRouteChildren {
   AppSettingsRouteRoute: typeof AppSettingsRouteRouteWithChildren
   AppDashboardRoute: typeof AppDashboardRoute
@@ -583,7 +615,7 @@ interface AppRouteRouteChildren {
   AppTweetsRoute: typeof AppTweetsRoute
   AppBookmarkIdRoute: typeof AppBookmarkIdRouteWithChildren
   AppCollectionCollectionRoute: typeof AppCollectionCollectionRoute
-  AppNewBookmarkRoute: typeof AppNewBookmarkRoute
+  AppNewBookmarkRoute: typeof AppNewBookmarkRouteWithChildren
   AppOauthConsentRoute: typeof AppOauthConsentRoute
   AppTagTagRoute: typeof AppTagTagRoute
   AppTypeTypeRoute: typeof AppTypeTypeRoute
@@ -603,7 +635,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppTweetsRoute: AppTweetsRoute,
   AppBookmarkIdRoute: AppBookmarkIdRouteWithChildren,
   AppCollectionCollectionRoute: AppCollectionCollectionRoute,
-  AppNewBookmarkRoute: AppNewBookmarkRoute,
+  AppNewBookmarkRoute: AppNewBookmarkRouteWithChildren,
   AppOauthConsentRoute: AppOauthConsentRoute,
   AppTagTagRoute: AppTagTagRoute,
   AppTypeTypeRoute: AppTypeTypeRoute,

--- a/packages/web/src/routes/_app/new.bookmark.confirmation.tsx
+++ b/packages/web/src/routes/_app/new.bookmark.confirmation.tsx
@@ -1,0 +1,22 @@
+import { CheckCircleIcon } from '@phosphor-icons/react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ROUTE_FEED } from '@/constants'
+
+export const Route = createFileRoute('/_app/new/bookmark/confirmation')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-m text-center">
+      <CheckCircleIcon weight="duotone" size={64} />
+      <h1 className="text-2xl font-semibold">Item added</h1>
+      <Link
+        to={ROUTE_FEED}
+        className="text-sm text-[var(--text-2)] underline underline-offset-2 hover:text-[var(--text-1)]"
+      >
+        Go to feed
+      </Link>
+    </div>
+  )
+}

--- a/packages/web/src/routes/_app/new.bookmark.confirmation.tsx
+++ b/packages/web/src/routes/_app/new.bookmark.confirmation.tsx
@@ -1,19 +1,37 @@
+import { ROUTE_FEED } from '@/constants'
 import { CheckCircleIcon } from '@phosphor-icons/react'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { ROUTE_FEED } from '@/constants'
 
 export const Route = createFileRoute('/_app/new/bookmark/confirmation')({
+  validateSearch: (search: {
+    id?: string
+    bookmarklet?: string
+  }): { id?: string; bookmarklet?: string } => ({
+    id: search.id,
+    bookmarklet: search.bookmarklet,
+  }),
   component: RouteComponent,
 })
 
 function RouteComponent() {
+  const { id } = Route.useSearch()
+
   return (
     <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-m text-center">
       <CheckCircleIcon weight="duotone" size={64} />
       <h1 className="text-2xl font-semibold">Item added</h1>
+      {id ? (
+        <Link
+          to="/bookmark/$id"
+          params={{ id }}
+          className="text-sm text-(--text-2) underline underline-offset-2 hover:text-(--text-1)"
+        >
+          View added item
+        </Link>
+      ) : null}
       <Link
         to={ROUTE_FEED}
-        className="text-sm text-[var(--text-2)] underline underline-offset-2 hover:text-[var(--text-1)]"
+        className="text-sm text-(--text-2) underline underline-offset-2 hover:text-(--text-1)"
       >
         Go to feed
       </Link>

--- a/packages/web/src/routes/_app/new.bookmark.tsx
+++ b/packages/web/src/routes/_app/new.bookmark.tsx
@@ -1,5 +1,10 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, useSearch } from '@tanstack/react-router'
+import {
+  createFileRoute,
+  Outlet,
+  useMatchRoute,
+  useSearch,
+} from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { BookmarkForm } from '@/components/BookmarkForm'
 import { Loader } from '@/components/Loader'
@@ -38,8 +43,17 @@ export const Route = createFileRoute('/_app/new/bookmark')({
 })
 
 function RouteComponent() {
+  const matchRoute = useMatchRoute()
+  const isConfirmationRoute = Boolean(
+    matchRoute({ to: '/new/bookmark/confirmation' }),
+  )
   const searchParams = useSearch({ from: '/_app/new/bookmark' })
   const { data } = useSuspenseQuery(getMetaOptions())
+
+  if (isConfirmationRoute) {
+    return <Outlet />
+  }
+
   return (
     <Suspense fallback={<Loader />}>
       <BookmarkForm


### PR DESCRIPTION
## Summary
This PR adds a dedicated confirmation page that displays after a user successfully creates a new bookmark, improving the user experience with visual feedback and clear navigation options.

## Key Changes
- **New Route**: Created `/new/bookmark/confirmation` route with a confirmation page component that displays a success message with a check circle icon
- **Updated BookmarkForm**: Modified the bookmark creation flow to navigate to the confirmation page instead of immediately redirecting to the feed and showing a toast notification
- **Route Registration**: Updated the generated route tree to include the new confirmation route in all relevant type definitions and route mappings
- **Constants**: Added `ROUTE_NEW_BOOKMARK_CONFIRMATION` constant for consistent route references

## Implementation Details
- The confirmation page (`new.bookmark.confirmation.tsx`) displays a centered success message with:
  - A duotone check circle icon (64px)
  - "Item added" heading
  - A link back to the feed
- The BookmarkForm now navigates to this confirmation page after successful bookmark creation, removing the inline toast notification
- The confirmation page provides a brief pause point for users to acknowledge the successful action before returning to the feed

https://claude.ai/code/session_01A2cagrVc971UVN6VC32aTN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a confirmation page after creating a bookmark via the bookmarklet. In this flow, we show a success screen with an optional link to the new item instead of an immediate redirect.

- **New Features**
  - Added /new/bookmark/confirmation with “Item added”, optional “View added item” (when id is present), and a link to the feed.
  - BookmarkForm now selects the inserted id (.single()); bookmarklet submissions go to the confirmation page, other flows keep the toast + redirect to /feed. Improved error handling resets submitting state and shows a clear error message.
  - Registered a nested confirmation route under /new/bookmark, added ROUTE_NEW_BOOKMARK_CONFIRMATION, and updated /new/bookmark to render an Outlet for the child route.

<sup>Written for commit 14a7a849cd65f85efbe44f124dd81011f43d8f4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

