### PR TITLE
feat: migrate base components to ZUI

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,6 +9,7 @@
     "@mrmartineau/strifx": "^0.2.0",
     "@mrmartineau/use-sound": "^5.1.0",
     "@mrmartineau/xtractr": "^0.2.7",
+    "@mrmartineau/zui": "^0.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@supabase/supabase-js": "^2.99.1",

--- a/packages/web/src/components/BookmarkFeedItem.tsx
+++ b/packages/web/src/components/BookmarkFeedItem.tsx
@@ -1,5 +1,4 @@
 import { NoteIcon, TwitterLogoIcon } from '@phosphor-icons/react'
-
 import { useClickBookmark } from '../hooks/useClickBookmark'
 import type { Bookmark, Collection } from '../types/db'
 import { fullPath } from '../utils/fullPath'

--- a/packages/web/src/components/BookmarkForm.css
+++ b/packages/web/src/components/BookmarkForm.css
@@ -28,7 +28,7 @@
   }
 
   .bookmark-form-image {
-    border-radius: var(--radii-l) var(--radii-l) 0 0;
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
     border: 1px solid var(--border);
     border-bottom: none;
     width: 100%;
@@ -42,5 +42,6 @@
     padding-bottom: max(var(--space-sm), env(safe-area-inset-bottom));
     background-color: var(--theme2);
     border-top: 1px solid var(--theme3);
+    border-radius: var(--radius-xl);;
   }
 }

--- a/packages/web/src/components/BookmarkForm.css
+++ b/packages/web/src/components/BookmarkForm.css
@@ -1,8 +1,8 @@
-@layer components {
+@layer zui.components {
   .bookmark-form {
     display: flex;
     flex-direction: column;
-    gap: var(--space-m);
+    gap: var(--space-md);
     flex-shrink: 0;
   }
 
@@ -14,13 +14,13 @@
   .bookmark-form-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: var(--space-s);
+    gap: var(--space-sm);
   }
 
   .bookmark-form-col {
     display: flex;
     flex-direction: column;
-    gap: var(--space-s);
+    gap: var(--space-sm);
 
     label {
       min-height: 20px;
@@ -37,10 +37,10 @@
   }
 
   .bookmark-form-footer {
-    margin-top: var(--space-m);
-    padding: var(--space-s);
-    padding-bottom: max(var(--space-s), env(safe-area-inset-bottom));
-    background-color: var(--theme1);
+    margin-top: var(--space-md);
+    padding: var(--space-sm);
+    padding-bottom: max(var(--space-sm), env(safe-area-inset-bottom));
+    background-color: var(--theme2);
     border-top: 1px solid var(--theme3);
   }
 }

--- a/packages/web/src/components/Button.css
+++ b/packages/web/src/components/Button.css
@@ -4,7 +4,7 @@
     align-items: center;
     gap: var(--space-2xs);
     justify-content: center;
-    border-radius: var(--radii-l);
+    border-radius: var(--radius-lg);
     color: #f5f5f0;
     transition: 200ms var(--ease-in-out-1);
     transition-property: background-color, border-color, color, opacity;

--- a/packages/web/src/components/Button.css
+++ b/packages/web/src/components/Button.css
@@ -42,44 +42,12 @@
     }
   }
 
-  .button-cmdk {
-    background-color: var(--theme2);
-    padding-inline-start: var(--space-xs);
-    padding-inline-end: var(--space-l);
-    color: var(--theme10);
-    border: 1px solid var(--border);
-    justify-content: flex-start;
-    max-width: 380px;
-    flex-grow: 1;
-    position: relative;
-    align-items: center;
-    font-weight: 500;
-    border-radius: var(--radii-l);
-
-    @media (min-width: 768px) {
-      min-width: 380px;
-    }
-
-    &:hover,
-    &[aria-pressed="true"] {
-      background-color: var(--theme3);
-      border-color: var(--theme8);
-    }
-    &:active {
-      box-shadow:
-        inset 0 0 0 1px var(--theme4),
-        0 0 0 1px var(--theme4);
-    }
-  }
-
   .button-collapsible {
-    padding: var(--space-3xs) var(--space-2xs) var(--space-3xs) var(--space-3xs) !important;
+    padding: var(--space-4xs) var(--space-2xs) var(--space-4xs) var(--space-3xs) !important;
     color: var(--theme10);
-    border-radius: var(--radii-m);
     width: 100%;
     gap: var(--space-2xs);
     justify-content: flex-start;
-    /* height: 32px; */
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.03em;

--- a/packages/web/src/components/Button.tsx
+++ b/packages/web/src/components/Button.tsx
@@ -19,7 +19,6 @@ const buttonVariants = cva(['zui-button'], {
       xs: 'zui-button-size-xs',
     },
     variant: {
-      cmdk: 'button-cmdk',
       collapsible: 'button-collapsible',
       default: '',
       destructive: 'zui-button-color-destructive',

--- a/packages/web/src/components/Button.tsx
+++ b/packages/web/src/components/Button.tsx
@@ -3,7 +3,7 @@ import { Slot as SlotPrimitive } from 'radix-ui'
 import type * as React from 'react'
 import { cn } from '@/utils/classnames'
 
-const buttonVariants = cva(['button-base', 'focus'], {
+const buttonVariants = cva(['zui-button'], {
   defaultVariants: {
     size: 'm',
     variant: 'default',
@@ -11,24 +11,23 @@ const buttonVariants = cva(['button-base', 'focus'], {
   variants: {
     size: {
       // @biome-ignore assist/source/useSortedKeys
-      '2xs': 'px-2xs py-3xs text-step--2 rounded-md',
+      '2xs': 'zui-button-size-xs',
       collapsible: 'h-6 w-6',
-      l: 'px-m py-s',
-      m: 'px-s py-2xs text-step--1',
-      s: 'px-s py-2xs text-step--1',
-      xs: 'px-xs py-3xs text-step--2',
+      l: 'zui-button-size-lg',
+      m: '',
+      s: 'zui-button-size-sm',
+      xs: 'zui-button-size-xs',
     },
     variant: {
       cmdk: 'button-cmdk',
       collapsible: 'button-collapsible',
-      default: 'bg-accent9 hover:bg-accent7',
-      destructive:
-        'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-      ghost: 'button-ghost',
-      icon: 'h-10 w-10 hover:bg-theme6 hover:text-theme10 button-icon',
-      nav: 'text-text hover:bg-theme3 rounded-lg shrink-0',
-      outline: 'button-outline',
-      secondary: 'bg-theme8 hover:bg-theme6',
+      default: '',
+      destructive: 'zui-button-color-destructive',
+      ghost: 'zui-button-variant-ghost',
+      icon: 'zui-button-icon',
+      nav: 'zui-button-variant-ghost rounded-lg shrink-0',
+      outline: 'zui-button-variant-outline',
+      secondary: 'zui-button-variant-subtle',
     },
   },
 })

--- a/packages/web/src/components/Card.css
+++ b/packages/web/src/components/Card.css
@@ -5,14 +5,13 @@
   gap: var(--space-2xs);
   position: relative;
   padding: var(--space-sm);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   transition: border 200ms var(--ease-in-out);
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
-  color: var(--color-text);
 
   &:hover,
   &:focus-within {
-    border-color: oklch(from var(--color-border) calc(l - .1) c h);
+    border-color: oklch(from var(--color-border) calc(l + .1) c h);
   }
 }

--- a/packages/web/src/components/Card.css
+++ b/packages/web/src/components/Card.css
@@ -4,15 +4,15 @@
   justify-content: space-between;
   gap: var(--space-2xs);
   position: relative;
-  padding: var(--space-s);
-  border-radius: var(--radii-l);
-  transition: border 200ms var(--ease-in-out-1);
-  background-color: var(--theme2);
-  border: 1px solid var(--border);
-  color: var(--theme10);
+  padding: var(--space-sm);
+  border-radius: var(--radius-lg);
+  transition: border 200ms var(--ease-in-out);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
 
   &:hover,
   &:focus-within {
-    border: 1px solid var(--theme4);
+    border-color: oklch(from var(--color-border) calc(l - .1) c h);
   }
 }

--- a/packages/web/src/components/CmdK/CmdK.css
+++ b/packages/web/src/components/CmdK/CmdK.css
@@ -12,7 +12,7 @@
   position: fixed;
   z-index: var(--z-2);
   overflow: auto;
-  border-radius: var(--radii-l);
+  border-radius: var(--radius-lg);
   top: 5dvh;
   left: 50%;
   transform: translateX(-50%);
@@ -83,7 +83,7 @@
     display: flex;
     border: 1px solid currentColor;
     color: var(--theme8);
-    border-radius: var(--radii-default);
+    border-radius: var(--radius-md);
     margin-inline-start: var(--space-md);
     position: absolute;
     top: 50%;

--- a/packages/web/src/components/CmdK/CmdK.css
+++ b/packages/web/src/components/CmdK/CmdK.css
@@ -31,7 +31,7 @@
   border: none;
   width: 100%;
   font-size: var(--step-0);
-  padding: var(--space-xs) var(--space-s);
+  padding: var(--space-xs) var(--space-sm);
   outline: none;
   background: var(--theme3);
   color: var(--text);
@@ -63,7 +63,7 @@
     padding: var(--space-3xs) var(--space-xs);
     display: flex;
     align-items: center;
-    background-color: var(--theme4);
+    background-color: var(--theme3);
     text-transform: uppercase;
     position: sticky;
     top: 0px;
@@ -72,7 +72,7 @@
 }
 
 .cmdk-empty {
-  padding: var(--space-s);
+  padding: var(--space-sm);
 }
 
 .cmdk-button-label {
@@ -84,7 +84,7 @@
     border: 1px solid currentColor;
     color: var(--theme8);
     border-radius: var(--radii-default);
-    margin-inline-start: var(--space-m);
+    margin-inline-start: var(--space-md);
     position: absolute;
     top: 50%;
     right: var(--space-2xs);
@@ -158,4 +158,26 @@
 [cmdk-loading] {
   padding: var(--space-2xs) var(--space-xs);
   text-align: center;
+}
+
+.button-cmdk {
+  justify-content: flex-start;
+  max-width: 380px;
+  flex-grow: 1;
+  position: relative;
+  align-items: center;
+  font-weight: 500;
+
+  @media (min-width: 768px) {
+    min-width: 380px;
+  }
+
+  &[aria-pressed="true"] {
+    background-color: var(--theme3);
+  }
+  &:active {
+    box-shadow:
+      inset 0 0 0 1px var(--theme4),
+      0 0 0 1px var(--theme4);
+  }
 }

--- a/packages/web/src/components/CmdK/CmdK.tsx
+++ b/packages/web/src/components/CmdK/CmdK.tsx
@@ -1,6 +1,7 @@
 import closeSound from '@mrmartineau/kit/sounds/close_001.mp3'
 import openSound from '@mrmartineau/kit/sounds/open_001.mp3'
 import useSound from '@mrmartineau/use-sound'
+import { Button } from '@mrmartineau/zui/react'
 import {
   ArrowElbowDownLeftIcon,
   ArrowFatLinesUpIcon,
@@ -26,11 +27,9 @@ import {
   useState,
 } from 'react'
 import formatTitle from 'title'
-import { Button } from '@/components/Button'
 import { useToggle } from '@/hooks/useToggle'
 import type { Tweet } from '@/types/db'
 import { getMetaOptions } from '@/utils/fetching/meta'
-
 import {
   ROUTE_DASHBOARD,
   ROUTE_FEED,
@@ -134,10 +133,10 @@ export const CmdK = () => {
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
-            variant="cmdk"
+            variant="subtle"
             aria-label="Search Otter"
             onClick={handleOpenCmdK}
-            className="h-10"
+            className="h-10 button-cmdk"
           >
             <MagnifyingGlassIcon weight="duotone" size="25" />
             Search

--- a/packages/web/src/components/CodeBlock.css
+++ b/packages/web/src/components/CodeBlock.css
@@ -7,10 +7,10 @@
 .pre {
   @extend .code-base;
   background-color: var(--theme5);
-  border-radius: var(--radii-l);
+  border-radius: var(--radius-lg);
   word-break: break-all;
   white-space: break-spaces;
-  padding: var(--space-s);
+  padding: var(--space-sm);
   margin-y: var(--space-xs);
   color: var(--theme11);
 

--- a/packages/web/src/components/CodeBlock.tsx
+++ b/packages/web/src/components/CodeBlock.tsx
@@ -1,17 +1,13 @@
 import type { ComponentProps, ReactNode } from 'react'
 import { cn } from '@/utils/classnames'
 
-import './CodeBlock.css'
-
 interface CodeBlockProps extends ComponentProps<'pre'> {
   children?: ReactNode
 }
 
 export const CodeBlock = ({ className, children, ...rest }: CodeBlockProps) => {
-  const CodeBlockClass = cn(className, 'pre')
-
   return (
-    <pre className={CodeBlockClass} {...rest}>
+    <pre className={cn('zui-pre', className)} {...rest}>
       {children}
     </pre>
   )
@@ -22,10 +18,8 @@ interface CodeProps extends ComponentProps<'code'> {
 }
 
 export const Code = ({ className, children, ...rest }: CodeProps) => {
-  const CodeClass = cn(className, 'code')
-
   return (
-    <code className={CodeClass} {...rest}>
+    <code className={cn('zui-code', className)} {...rest}>
       {children}
     </code>
   )

--- a/packages/web/src/components/Collapsible.tsx
+++ b/packages/web/src/components/Collapsible.tsx
@@ -1,10 +1,10 @@
 import switchOffSfx from '@mrmartineau/kit/sounds/switch-off.mp3'
 import switchOnSfx from '@mrmartineau/kit/sounds/switch-on.mp3'
 import useSound from '@mrmartineau/use-sound'
+import { Button } from '@mrmartineau/zui/react'
 import { CaretUpDownIcon } from '@phosphor-icons/react'
 import { Collapsible as CollapsiblePrimitive } from 'radix-ui'
 import { type ComponentProps, useCallback } from 'react'
-import { Button } from '@/components/Button'
 
 import { Flex } from './Flex'
 import { useUser } from './UserProvider'
@@ -58,7 +58,7 @@ export const CollapsibleTrigger = ({
 }: ComponentProps<typeof CollapsiblePrimitive.Trigger>) => {
   return (
     <CollapsiblePrimitive.Trigger asChild {...rest}>
-      <Button variant="collapsible">
+      <Button variant="ghost" className="button-collapsible">
         <div className="rounded bg-theme3 p-1">
           <CaretUpDownIcon weight="duotone" size={14} />
         </div>

--- a/packages/web/src/components/Combobox.tsx
+++ b/packages/web/src/components/Combobox.tsx
@@ -13,7 +13,7 @@ export const comboboxStyles: StylesConfig<
     ...provided,
     backgroundColor: 'var(--theme2)',
     borderColor: state.isFocused ? 'var(--theme6)' : 'var(--theme3)',
-    borderRadius: 'var(--radii-l)',
+    borderRadius: 'var(--radius-lg)',
     borderWidth: '1px',
     boxShadow: state.isFocused
       ? '0 0 0 2px var(--focus)'
@@ -24,7 +24,7 @@ export const comboboxStyles: StylesConfig<
     ...provided,
     alignItems: 'center',
     backgroundColor: 'var(--theme4)',
-    borderRadius: 'var(--radii-default)',
+    borderRadius: 'var(--radius-md)',
     color: 'var(--theme8)',
     fontSize: 'var(--step--1)',
     padding: 'var(--space-3xs)',
@@ -36,7 +36,7 @@ export const comboboxStyles: StylesConfig<
       backgroundColor: 'var(--theme6)',
       color: 'var(--theme10)',
     },
-    borderRadius: 'var(--radii-full)',
+    borderRadius: 'var(--radius-full)',
     cursor: 'pointer',
     flexShrink: 0,
     height: '1.5em',

--- a/packages/web/src/components/Container.css
+++ b/packages/web/src/components/Container.css
@@ -2,7 +2,7 @@
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding-x: var(--space-s);
+  padding-inline: var(--space-sm);
 }
 
 .otter-container-auth {

--- a/packages/web/src/components/Dialog.css
+++ b/packages/web/src/components/Dialog.css
@@ -56,7 +56,7 @@
   width: 100vw;
   min-height: 100dvh;
   overflow: auto;
-  padding: var(--space-m);
+  padding: var(--space-md);
   z-index: 3000;
 
   &:focus {
@@ -68,7 +68,7 @@
 .DialogContent--center {
   left: 0;
   @media (min-width: 768px) {
-    border-radius: var(--radii-default);
+    border-radius: var(--radius-md);
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);

--- a/packages/web/src/components/Dialog.tsx
+++ b/packages/web/src/components/Dialog.tsx
@@ -23,7 +23,7 @@ interface DialogContentProps
   children: ReactNode
 }
 
-const dialogContentVariants = cva('DialogContent', {
+const dialogContentVariants = cva('zui-dialog DialogContent', {
   defaultVariants: {
     placement: 'center',
     width: 'm',
@@ -66,16 +66,20 @@ export const DialogContent = ({
         </DialogPrimitive.Close>
       </div>
       {title ? (
-        <DialogPrimitive.Title className="DialogTitle">
-          {title}
-        </DialogPrimitive.Title>
+        <div className="zui-dialog-header">
+          <DialogPrimitive.Title className="zui-dialog-title">
+            {title}
+          </DialogPrimitive.Title>
+          {description ? (
+            <DialogPrimitive.Description className="zui-dialog-description">
+              {description}
+            </DialogPrimitive.Description>
+          ) : null}
+        </div>
       ) : null}
-      {description ? (
-        <DialogPrimitive.Description className="DialogDescription">
-          {description}
-        </DialogPrimitive.Description>
-      ) : null}
-      {children}
+      <div className="zui-dialog-body">
+        {children}
+      </div>
     </DialogPrimitive.Content>
   </DialogPrimitive.Portal>
 )

--- a/packages/web/src/components/Dialog.tsx
+++ b/packages/web/src/components/Dialog.tsx
@@ -23,7 +23,7 @@ interface DialogContentProps
   children: ReactNode
 }
 
-const dialogContentVariants = cva('zui-dialog DialogContent', {
+const dialogContentVariants = cva('DialogContent', {
   defaultVariants: {
     placement: 'center',
     width: 'm',

--- a/packages/web/src/components/Feed.css
+++ b/packages/web/src/components/Feed.css
@@ -3,8 +3,8 @@
 
 .feed-simple-grid {
   display: grid;
-  margin-top: var(--space-md);
-  gap: var(--space-md);
+  margin-top: var(--space-xs);
+  gap: var(--space-sm);
 
   @media (min-width: 500px) {
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
@@ -46,13 +46,13 @@
 }
 
 .feed-avatar {
-  border-radius: var(--radii-full);
+  border-radius: var(--radius-full);
   width: 50px;
   height: 50px;
 }
 
 .feed-image {
-  border-radius: var(--radii-md);
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
   width: 150px;
   max-width: 150px;
@@ -60,7 +60,7 @@
 }
 
 .feed-item-note {
-  border-radius: var(--radii-md);
+  border-radius: var(--radius-md);
   background-color: var(--theme2);
   border: 1px solid var(--color-border);
   padding: var(--space-xs);

--- a/packages/web/src/components/Feed.css
+++ b/packages/web/src/components/Feed.css
@@ -3,8 +3,8 @@
 
 .feed-simple-grid {
   display: grid;
-  margin-top: var(--space-m);
-  gap: var(--space-m);
+  margin-top: var(--space-md);
+  gap: var(--space-md);
 
   @media (min-width: 500px) {
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
@@ -52,7 +52,7 @@
 }
 
 .feed-image {
-  border-radius: var(--radii-m);
+  border-radius: var(--radii-md);
   border: 1px solid var(--border);
   width: 150px;
   max-width: 150px;
@@ -60,9 +60,9 @@
 }
 
 .feed-item-note {
-  border-radius: var(--radii-m);
+  border-radius: var(--radii-md);
   background-color: var(--theme2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   padding: var(--space-xs);
 }
 

--- a/packages/web/src/components/Feed.tsx
+++ b/packages/web/src/components/Feed.tsx
@@ -1,9 +1,9 @@
+import { Button } from '@mrmartineau/zui/react'
 import { EyeIcon, StarIcon } from '@phosphor-icons/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import type { FileRouteTypes } from '@tanstack/react-router'
 import { memo, type ReactNode } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import { Button } from '@/components/Button'
 import { CONTENT, DEFAULT_API_RESPONSE_LIMIT } from '@/constants'
 import { useFeedOptions } from '@/hooks/useFeedOptions'
 import { type FeedItemModel, useGroupByDate } from '@/hooks/useGroupByDate'
@@ -107,7 +107,7 @@ export const Feed = memo(
               <Flex gap="3xs">
                 <Button
                   onClick={() => handleToggleState('star')}
-                  size="xs"
+                  size="sm"
                   variant="ghost"
                   aria-pressed={starQuery}
                 >
@@ -116,7 +116,7 @@ export const Feed = memo(
                 </Button>
                 <Button
                   onClick={() => handleToggleState('public')}
-                  size="xs"
+                  size="sm"
                   variant="ghost"
                   aria-pressed={publicQuery}
                 >
@@ -180,7 +180,7 @@ export const Feed = memo(
             )}
           </div>
         ) : (
-          <div className="mt-sm grid gap-md">
+          <div className="mt-sm grid gap-sm">
             {items?.length ? (
               items.map((item) => {
                 if (!item) {

--- a/packages/web/src/components/Feed.tsx
+++ b/packages/web/src/components/Feed.tsx
@@ -144,7 +144,7 @@ export const Feed = memo(
         </Flex>
 
         {allowGroupByDate && groupByDate ? (
-          <div className="bp2:gap-m grid gap-s">
+          <div className="bp2:gap-m grid gap-sm">
             {groupedItems?.length ? (
               groupedItems.map((groupedItem) => (
                 <div key={groupedItem.date}>
@@ -180,7 +180,7 @@ export const Feed = memo(
             )}
           </div>
         ) : (
-          <div className="mt-m grid gap-m">
+          <div className="mt-sm grid gap-md">
             {items?.length ? (
               items.map((item) => {
                 if (!item) {

--- a/packages/web/src/components/Heading.css
+++ b/packages/web/src/components/Heading.css
@@ -11,7 +11,7 @@
 
 .heading-1 {
   font-size: var(--step-2);
-  margin-top: var(--space-l);
+  margin-top: var(--space-lg);
 }
 
 .heading-date {

--- a/packages/web/src/components/Heading.css
+++ b/packages/web/src/components/Heading.css
@@ -1,9 +1,10 @@
+
 .heading {
   font-family: var(--font-sans);
   line-height: var(--line-height-heading);
-  font-weight: 300;
-  margin-top: var(--space-m);
-  margin-bottom: var(--space-s);
+  font-weight: 400;
+  margin-top: var(--space-md);
+  margin-bottom: var(--space-sm);
   color: var(--text);
   font-variation-settings: unset;
 }

--- a/packages/web/src/components/IconControl.css
+++ b/packages/web/src/components/IconControl.css
@@ -3,7 +3,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: var(--radii-full);
+    border-radius: var(--radius-full);
     font-size: var(--step--2);
     min-width: 80px;
     width: 10%;
@@ -47,7 +47,7 @@
     grid-column-gap: var(--space-2xs);
     padding: var(--space-2xs);
     text-align: center;
-    border-radius: var(--radii-l);
+    border-radius: var(--radius-lg);
     --activeColor: var(--accent9);
     font-weight: 500;
     letter-spacing: 0.02em;

--- a/packages/web/src/components/Input.css
+++ b/packages/web/src/components/Input.css
@@ -2,7 +2,7 @@
   .input-base {
     width: 100%;
     display: flex;
-    border-radius: var(--radii-l);
+    border-radius: var(--radius-lg);
     background-color: var(--theme2);
     border: 1px solid var(--theme3);
     padding: var(--space-3xs) var(--space-2xs);

--- a/packages/web/src/components/Input.tsx
+++ b/packages/web/src/components/Input.tsx
@@ -9,8 +9,7 @@ const Input = ({ className, type, ...props }: InputProps) => {
     <input
       type={type}
       className={cn(
-        'input-base',
-        'focus',
+        'zui-input',
         'file:border-0 file:bg-transparent file:text-sm file:font-medium',
         className,
       )}

--- a/packages/web/src/components/Label.tsx
+++ b/packages/web/src/components/Label.tsx
@@ -1,19 +1,12 @@
-import { Label as LabelPrimitive } from 'radix-ui'
 import type { ComponentProps } from 'react'
 import { cn } from '@/utils/classnames'
 
-const Label = ({
-  className,
-  ...props
-}: ComponentProps<typeof LabelPrimitive.Root>) => (
-  <LabelPrimitive.Root
-    className={`${cn(
-      'flex items-center gap-xs ml-1 tracking-wide uppercase font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-step--2',
-      className,
-    )} text-theme8`}
+const Label = ({ className, ...props }: ComponentProps<'label'>) => (
+  <label
+    className={cn('zui-label', className)}
     {...props}
   />
 )
-Label.displayName = LabelPrimitive.Root.displayName
+Label.displayName = 'Label'
 
 export { Label }

--- a/packages/web/src/components/Link.css
+++ b/packages/web/src/components/Link.css
@@ -1,152 +1,154 @@
-.link-base {
-  --color: inherit;
-  --decoration-color: var(--theme9);
-  display: inline-flex;
-  flex-shrink: 0;
-  outline: none;
-  text-decoration-line: none;
-  text-underline-offset: 3px;
-  text-decoration-color: var(--decoration-color);
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  line-height: inherit;
-  cursor: pointer;
-  transition: color var(--transition);
-  color: var(--color);
-  border-radius: var(--radii-s);
-
-  &:hover {
-    text-decoration-line: underline;
-  }
-}
-.link-default {
-  --color: inherit;
-  --decoration-color: var(--theme9);
-}
-.link-accent {
-  --color: var(--accent10);
-  --text-decoration-color: var(--accent4);
-}
-.link-subtle {
-  --color: var(--theme8);
-  --text-decoration-color: var(--theme5);
-}
-.link-sidebar {
-  --color: var(--theme10);
-  font-size: var(--step--2);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-3xs) var(--space-2xs);
-  column-gap: var(--space-m);
-  border-radius: var(--radii-m);
-  line-height: 18px;
-
-  &:hover {
-    color: var(--theme11);
-    background-color: var(--theme5);
-    text-decoration: none;
-  }
-
-  &.is-active {
-    background-color: var(--accent6);
-    --color: var(--accent11);
-    font-weight: 500;
+@layer zui.components {
+  .link-base {
+    --color: inherit;
+    --decoration-color: var(--theme8);
+    display: inline-flex;
+    flex-shrink: 0;
+    outline: none;
+    text-decoration-line: none;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--decoration-color);
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    line-height: inherit;
+    cursor: pointer;
+    transition: color var(--transition);
+    color: var(--color);
+    border-radius: var(--radii-s);
 
     &:hover {
-      background-color: var(--accent7);
-      --color: var(--accent11);
+      text-decoration-line: underline;
     }
   }
-}
+  .link-default {
+    --color: inherit;
+    --decoration-color: var(--theme9);
+  }
+  .link-accent {
+    --color: var(--accent10);
+    --text-decoration-color: var(--accent4);
+  }
+  .link-subtle {
+    --color: var(--theme8);
+    --text-decoration-color: var(--theme5);
+  }
+  .link-sidebar {
+    --color: var(--color-muted);
+    font-size: var(--step--2);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-4xs) var(--space-2xs);
+    column-gap: var(--space-m);
+    border-radius: var(--radii-m);
+    line-height: 18px;
 
-.link-sidebar-inner {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3xs);
-}
+    &:hover {
+      color: var(--theme11);
+      background-color: var(--theme5);
+      text-decoration: none;
+    }
 
-.link-logo {
-  --color: var(--accent10);
-  font-size: var(--step-1);
-  font-variation-settings:
-    "wght" 900,
-    "wdth" 105;
-  gap: var(--space-xs);
-  align-items: center;
+    &.is-active {
+      background-color: var(--color-background);
+      --color: var(--accent12);
+      font-weight: 500;
 
-  &:hover {
-    text-decoration: none;
+      &:hover {
+        background-color: var(--accent7);
+        --color: var(--accent11);
+      }
+    }
   }
 
-  .emoji {
-    display: none;
+  .link-sidebar-inner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3xs);
   }
 
-  @media (min-width: 500px) {
-    font-size: var(--step-2);
+  .link-logo {
+    --color: var(--accent10);
+    font-size: var(--step-1);
+    font-variation-settings:
+      "wght" 900,
+      "wdth" 105;
+    gap: var(--space-xs);
+    align-items: center;
+
+    &:hover {
+      text-decoration: none;
+    }
+
     .emoji {
-      display: block;
+      display: none;
+    }
+
+    @media (min-width: 500px) {
+      font-size: var(--step-2);
+      .emoji {
+        display: block;
+      }
     }
   }
-}
 
-.link-add {
-  background-color: var(--theme4);
-  color: var(--theme11);
-  border-radius: var(--radii-pill);
-  padding-x: var(--space-2xs);
-  padding-y: var(--space-3xs);
-  font-size: var(--step--2);
-  font-family: var(--font-mono);
-  text-transform: uppercase;
-  align-items: center;
-  gap: var(--space-3xs);
-
-  &:hover {
-    text-decoration: none;
-    background-color: var(--theme6);
-    color: var(--theme12);
-  }
-}
-
-.link-feed-title {
-  align-items: flex-start;
-  gap: var(--space-xs);
-  font-size: var(--step-0);
-  font-variation-settings:
-    "wght" 500,
-    "wdth" 105;
-  color: var(--theme11);
-}
-
-.link-fab {
-  --color: var(--theme12);
-  border-radius: var(--radii-l);
-  height: 40px;
-  width: 40px;
-  background-color: var(--accent8);
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  justify-content: center;
-  box-shadow: 0 2px 10px var(--theme3);
-  cursor: pointer;
-
-  &:hover {
-    background-color: var(--accent6);
-    color: var(--color);
-  }
-}
-
-.link-tag {
-  border: 1px solid var(--theme5);
-  border-radius: var(--radii-pill);
-  padding-x: var(--space-2xs);
-  background-color: var(--theme3);
-
-  &:hover {
-    border-color: var(--theme6);
+  .link-add {
     background-color: var(--theme4);
-    text-decoration-line: none;
+    color: var(--theme11);
+    border-radius: var(--radii-pill);
+    padding-x: var(--space-2xs);
+    padding-y: var(--space-3xs);
+    font-size: var(--step--2);
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    align-items: center;
+    gap: var(--space-3xs);
+
+    &:hover {
+      text-decoration: none;
+      background-color: var(--theme6);
+      color: var(--theme12);
+    }
+  }
+
+  .link-feed-title {
+    align-items: flex-start;
+    gap: var(--space-xs);
+    font-size: var(--step-0);
+    font-variation-settings:
+      "wght" 500,
+      "wdth" 105;
+    color: var(--theme11);
+  }
+
+  .link-fab {
+    --color: var(--theme12);
+    border-radius: var(--radii-l);
+    height: 40px;
+    width: 40px;
+    background-color: var(--accent8);
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    justify-content: center;
+    box-shadow: 0 2px 10px var(--theme3);
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--accent6);
+      color: var(--color);
+    }
+  }
+
+  .link-tag {
+    border: 1px solid var(--theme5);
+    border-radius: var(--radii-pill);
+    padding-x: var(--space-2xs);
+    background-color: var(--theme3);
+
+    &:hover {
+      border-color: var(--theme6);
+      background-color: var(--theme4);
+      text-decoration-line: none;
+    }
   }
 }

--- a/packages/web/src/components/Link.css
+++ b/packages/web/src/components/Link.css
@@ -13,7 +13,7 @@
     cursor: pointer;
     transition: color var(--transition);
     color: var(--color);
-    border-radius: var(--radii-s);
+    border-radius: var(--radius-sm);
 
     &:hover {
       text-decoration-line: underline;
@@ -39,7 +39,7 @@
     justify-content: space-between;
     padding: var(--space-4xs) var(--space-2xs);
     column-gap: var(--space-m);
-    border-radius: var(--radii-m);
+    border-radius: var(--radius-md);
     line-height: 18px;
 
     &:hover {
@@ -94,7 +94,7 @@
   .link-add {
     background-color: var(--theme4);
     color: var(--theme11);
-    border-radius: var(--radii-pill);
+    border-radius: var(--radius-pill);
     padding-x: var(--space-2xs);
     padding-y: var(--space-3xs);
     font-size: var(--step--2);
@@ -122,7 +122,7 @@
 
   .link-fab {
     --color: var(--theme12);
-    border-radius: var(--radii-l);
+    border-radius: var(--radius-lg);
     height: 40px;
     width: 40px;
     background-color: var(--accent8);
@@ -141,7 +141,7 @@
 
   .link-tag {
     border: 1px solid var(--theme5);
-    border-radius: var(--radii-pill);
+    border-radius: var(--radius-pill);
     padding-x: var(--space-2xs);
     background-color: var(--theme3);
 

--- a/packages/web/src/components/Link.tsx
+++ b/packages/web/src/components/Link.tsx
@@ -3,21 +3,21 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import type * as React from 'react'
 import { cn } from '@/utils/classnames'
 
-const linkVariants = cva(['link-base', 'focus'], {
+const linkVariants = cva([], {
   defaultVariants: {
     variant: 'default',
   },
   variants: {
     variant: {
-      accent: 'link-accent',
-      add: 'link-add',
-      default: 'link-default',
-      fab: 'link-fab',
-      feedTitle: 'link-feed-title',
-      logo: 'link-logo',
-      sidebar: 'link-sidebar',
-      subtle: 'link-subtle',
-      tag: 'link-tag',
+      accent: 'zui-link link-accent',
+      add: 'link-base link-add',
+      default: 'zui-link',
+      fab: 'link-base link-fab',
+      feedTitle: 'link-base link-feed-title',
+      logo: 'link-base link-logo',
+      sidebar: 'link-base link-sidebar',
+      subtle: 'link-base link-subtle',
+      tag: 'link-base link-tag',
     },
   },
 })
@@ -31,7 +31,7 @@ export interface LinkProps
 const Link = ({ className, variant, isActive, href, ...props }: LinkProps) => {
   return (
     <TanstackLink
-      className={cn(linkVariants({ className, variant }), {
+      className={cn(linkVariants({ variant }), className, {
         'is-active': isActive,
       })}
       to={href}

--- a/packages/web/src/components/Markdown.tsx
+++ b/packages/web/src/components/Markdown.tsx
@@ -45,7 +45,7 @@ export const Markdown = ({
     <div>
       <article
         ref={contentRef}
-        className={`markdown flow last:mb- ${
+        className={`prose flow ${
           isExpanded ? 'line-clamp-none' : 'line-clamp-5'
         } text-step-${textSize}`}
       >

--- a/packages/web/src/components/MediaCard.tsx
+++ b/packages/web/src/components/MediaCard.tsx
@@ -35,8 +35,6 @@ export const MediaCard = ({
     index: media.sort_order ?? 0,
     type: 'item',
   })
-  // console.log(`🚀 ~ MediaCard ~ data:`, data.sortable.index, index, newIndex)
-  // const index = data.sortable.index
 
   const deleteMedia = useDeleteMedia()
 
@@ -59,13 +57,15 @@ export const MediaCard = ({
       data-index={media.sort_order ?? 0}
       data-media-id={media.media_id}
     >
-      {media.image ? (
-        <img src={media.image} alt={media.name} className="rounded-md" />
-      ) : (
-        <div className="media-card-title">{media.name}</div>
-      )}
-
-      {media.rating ? <Rating rating={media.rating} /> : null}
+      <div className="media-card-wrapper">
+        <div>
+          <div className="media-card-title">{media.name}</div>
+          {media.rating ? <Rating rating={media.rating} /> : null}
+        </div>
+        {media.image ? (
+          <img src={media.image} alt={media.name} className="rounded-md" />
+        ) : null}
+      </div>
 
       <TooltipProvider delayDuration={800} skipDelayDuration={500}>
         <div className="feed-item-footer">

--- a/packages/web/src/components/MediaColumn.tsx
+++ b/packages/web/src/components/MediaColumn.tsx
@@ -63,7 +63,7 @@ export const MediaColumn = ({
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        <div className={cn('space-y-3', { 'bg-gray-400': isOverContainer })}>
+        <div className={cn('flex flex-col gap-3', { 'bg-gray-400': isOverContainer })}>
           {media.map((item) => (
             <MediaCard
               key={item.id}

--- a/packages/web/src/components/TagList/TagList.css
+++ b/packages/web/src/components/TagList/TagList.css
@@ -1,6 +1,6 @@
 .tagListItem {
   position: relative;
-  border-radius: var(--radii-m);
+  border-radius: var(--radius-md);
 
   &:hover {
     background-color: var(--theme3);

--- a/packages/web/src/components/Text.css
+++ b/packages/web/src/components/Text.css
@@ -1,6 +1,6 @@
 .text-count {
   font-size: var(--step--3);
   font-family: var(--font-mono);
-  color: var(--theme9);
+  color: var(--color-faint);
   line-height: 1;
 }

--- a/packages/web/src/components/Textarea.tsx
+++ b/packages/web/src/components/Textarea.tsx
@@ -8,7 +8,7 @@ export interface TextareaProps extends TextareaAutosizeProps {}
 const Textarea = ({ className, ...props }: TextareaProps) => {
   return (
     <TextareaAutosize
-      className={cn('input-base focus min-h-[80px]', className)}
+      className={cn('zui-textarea min-h-[80px]', className)}
       {...props}
     />
   )

--- a/packages/web/src/components/Tooltip.tsx
+++ b/packages/web/src/components/Tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipContent = ({
     sideOffset={sideOffset}
     collisionPadding={10}
     className={cn(
-      'text-text z-50 overflow-hidden rounded-md border bg-theme2 px-xs py-3xs text-sm shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'text-text z-50 overflow-hidden rounded-full border bg-theme2 px-2xs py-4xs text-sm shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}

--- a/packages/web/src/components/TypeRadio.css
+++ b/packages/web/src/components/TypeRadio.css
@@ -21,9 +21,9 @@
 
   &:hover + .type-radio-label,
   &:checked + .type-radio-label {
-    border-color: var(--accent9);
-    background-color: var(--accent3);
-    color: var(--accent9);
+    border-color: currentColor;
+    background-color: var(--theme4);
+    color: var(--theme9);
   }
 
   &:checked + .type-radio-label {
@@ -40,7 +40,7 @@
   gap: var(--space-2xs);
   background-color: var(--theme2);
   border: 1px solid var(--theme3);
-  border-radius: var(--radii-full);
+  border-radius: var(--radius-full);
   padding: var(--space-4xs) var(--space-2xs);
   cursor: pointer;
   transition: all 200ms var(--ease-in-out-1);

--- a/packages/web/src/components/TypeRadio.css
+++ b/packages/web/src/components/TypeRadio.css
@@ -27,7 +27,7 @@
   }
 
   &:checked + .type-radio-label {
-    padding-x: var(--space-m);
+    padding-x: var(--space-xs);
   }
 }
 
@@ -41,7 +41,7 @@
   background-color: var(--theme2);
   border: 1px solid var(--theme3);
   border-radius: var(--radii-full);
-  padding: var(--space-3xs) var(--space-xs);
+  padding: var(--space-4xs) var(--space-2xs);
   cursor: pointer;
   transition: all 200ms var(--ease-in-out-1);
   font-size: var(--step--2);

--- a/packages/web/src/routes/_app/bookmark.$id.read.tsx
+++ b/packages/web/src/routes/_app/bookmark.$id.read.tsx
@@ -1,9 +1,9 @@
+import { Button } from '@mrmartineau/zui/react'
 import { ArrowLeftIcon, ArrowSquareOutIcon } from '@phosphor-icons/react'
 import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import urlJoin from 'proper-url-join'
 import { useState } from 'react'
-import { Button } from '@/components/Button'
 import { Flex } from '@/components/Flex'
 import { Link } from '@/components/Link'
 import { Loader } from '@/components/Loader'
@@ -157,9 +157,10 @@ function RouteComponent() {
               role="tab"
               aria-selected={viewMode === 'read'}
               onClick={() => setViewMode('read')}
-              variant={viewMode === 'read' ? 'default' : 'ghost'}
+              variant={viewMode === 'read' ? 'subtle' : 'ghost'}
+              shape="soft"
               className={`rounded-full grow`}
-              >
+            >
               Read
             </Button>
             <Button
@@ -167,8 +168,9 @@ function RouteComponent() {
               role="tab"
               aria-selected={viewMode === 'summary'}
               onClick={() => setViewMode('summary')}
-              variant={viewMode === 'summary' ? 'default' : 'ghost'}
-              className={`rounded-full grow`}
+              variant={viewMode === 'summary' ? 'subtle' : 'ghost'}
+              shape="soft"
+              className={`grow`}
             >
               Summary
             </Button>

--- a/packages/web/src/routes/_app/dashboard.tsx
+++ b/packages/web/src/routes/_app/dashboard.tsx
@@ -60,7 +60,7 @@ function Index() {
   )
 
   return (
-    <div className="flex flex-col gap-l">
+    <div className="flex flex-col gap-md">
       {dashboard?.recent?.length ? (
         <FeedSimple items={dashboard.recent} title="Recent" />
       ) : null}

--- a/packages/web/src/routes/_app/layout.css
+++ b/packages/web/src/routes/_app/layout.css
@@ -59,7 +59,7 @@
   margin-top: var(--header-height);
   height: calc(100dvh - var(--header-height));
   transform: translateX(calc(-1 * var(--sidebar-width)));
-  background-color: var(--theme2);
+  background-color: var(--color-surface);
   overflow-y: auto;
   border-right: 1px solid var(--border);
 
@@ -114,7 +114,7 @@
 }
 
 .otter-content-pane-inner {
-  padding-top: var(--space-m);
+  padding-top: var(--space-md);
   padding-bottom: var(--space-xl);
   min-height: 100%;
 }

--- a/packages/web/src/routes/_app/media.css
+++ b/packages/web/src/routes/_app/media.css
@@ -1,11 +1,17 @@
 .media-columns {
   display: grid;
   grid-template-columns: 268px 268px 268px;
-  gap: var(--space-m);
+  gap: var(--space-md);
   overflow-x: auto;
   width: 100dvw;
 
   @media (min-width: 768px) {
     width: calc(100dvw - var(--sidebar-width) - 40px);
   }
+}
+
+.media-card-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 50px;
+  gap: var(--space-sm);
 }

--- a/packages/web/src/routes/_app/media.tsx
+++ b/packages/web/src/routes/_app/media.tsx
@@ -143,14 +143,14 @@ function RouteComponent() {
   }, [media])
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Media</h1>
       </div>
 
       {/* Filters */}
       <div className="flex gap-4 justify-between flex-wrap">
-        <div className="space-y-4">
+        <div className="flex flex-col gap-3">
           <div className="flex gap-4">
             <div className="flex-1">
               <Input

--- a/packages/web/src/styles/focus.css
+++ b/packages/web/src/styles/focus.css
@@ -1,28 +1,12 @@
 @layer components {
   .focus {
-    &:focus {
-      outline: 0;
-      box-shadow: 0px 0px 0px 3px var(--focus);
+    &:focus-visible {
+      outline: var(--focus-ring);
+      outline-offset: var(--focus-ring-offset);
     }
 
     &:focus:not(:focus-visible) {
-      box-shadow: none;
-    }
-
-    &:focus-visible {
-      outline: 0;
-      --ring-offset-width: 2px;
-      --ring-offset-color: var(--theme1);
-      --ring-offset-shadow: var(--tw-ring-inset-color) 0 0 0
-        var(--ring-offset-width) var(--ring-offset-color);
-      --ring-shadow: var(--tw-ring-inset-color) 0 0 0
-        calc(2px + var(--ring-offset-width)) var(--focus);
-      box-shadow:
-        var(--tw-ring-inset-color) 0 0 0 var(--ring-offset-width)
-        var(--ring-offset-color),
-        var(--tw-ring-inset-color) 0 0 0 calc(2px + var(--ring-offset-width))
-        var(--focus),
-        0 0 rgba(0, 0, 0, 0);
+      outline: none;
     }
   }
 }

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "@mrmartineau/zui/css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -2,15 +2,14 @@
 @import "tw-animate-css";
 @import "@mrmartineau/zui/css";
 
-@custom-variant dark (&:is(.dark *));
+/* @custom-variant dark (&:is(.dark *)); */
 
+@import "./zui-theme.css";
 @import "./colors.css";
 @import "./vars.css";
 @import "./media.css";
 @import "./easings.css";
-@import "./utopia.css";
 @import "./fonts.css";
-@import "./typography.css";
 @import "./focus.css";
 @import "../routes/_app/layout.css";
 @import "../routes/_app/media.css";

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -54,10 +54,10 @@
 }
 
 @theme inline {
-  --radius-sm: var(--radii-s);
-  --radius-md: var(--radii-m);
-  --radius-lg: var(--radii-l);
-  --radius-xl: var(--radii-xl);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/packages/web/src/styles/typography.css
+++ b/packages/web/src/styles/typography.css
@@ -114,11 +114,11 @@
   }
 
   .lede + * {
-    --flow-space: var(---space-m);
+    --flow-space: var(---space-md);
   }
 
   hr {
     border-top-color: var(--text);
-    margin: var(--space-m);
+    margin: var(--space-md);
   }
 }

--- a/packages/web/src/styles/vars.css
+++ b/packages/web/src/styles/vars.css
@@ -28,17 +28,7 @@
 
     /* Transitions */
     --transition: 0.2s var(--ease-in-out-4);
-
-    /* Radii — alias ZUI tokens */
-    --radii-none: 0;
-    --radii-s: var(--radius-sm);
-    --radii-default: var(--radius-md);
-    --radii-m: var(--radius-md);
-    --radii-l: var(--radius-lg);
-    --radii-xl: var(--radius-xl);
-    --radii-full: var(--radius-full);
-    --radii-round: var(--radius-round);
-    --radii-pill: var(--radius-full);
+    --radius-pill: var(--radius-full);
 
     /* Theme scale — mapped to ZUI mist palette via light-dark() */
     --theme1:  light-dark(var(--color-mauve-50),  var(--color-mauve-950));

--- a/packages/web/src/styles/vars.css
+++ b/packages/web/src/styles/vars.css
@@ -41,32 +41,32 @@
     --radii-pill: var(--radius-full);
 
     /* Theme scale — mapped to ZUI mist palette via light-dark() */
-    --theme1:  light-dark(var(--color-mist-50),  var(--color-mist-950));
-    --theme2:  light-dark(var(--color-mist-100), var(--color-mist-900));
-    --theme3:  light-dark(var(--color-mist-200), var(--color-mist-800));
-    --theme4:  light-dark(var(--color-mist-300), var(--color-mist-700));
-    --theme5:  light-dark(var(--color-mist-300), var(--color-mist-700));
-    --theme6:  light-dark(var(--color-mist-400), var(--color-mist-600));
-    --theme7:  light-dark(var(--color-mist-400), var(--color-mist-500));
-    --theme8:  light-dark(var(--color-mist-500), var(--color-mist-500));
-    --theme9:  light-dark(var(--color-mist-500), var(--color-mist-400));
-    --theme10: light-dark(var(--color-mist-600), var(--color-mist-300));
-    --theme11: light-dark(var(--color-mist-700), var(--color-mist-200));
-    --theme12: light-dark(var(--color-mist-800), var(--color-mist-100));
+    --theme1:  light-dark(var(--color-mauve-50),  var(--color-mauve-950));
+    --theme2:  light-dark(var(--color-mauve-100), var(--color-mauve-900));
+    --theme3:  light-dark(var(--color-mauve-200), var(--color-mauve-800));
+    --theme4:  light-dark(var(--color-mauve-300), var(--color-mauve-700));
+    --theme5:  light-dark(var(--color-mauve-300), var(--color-mauve-700));
+    --theme6:  light-dark(var(--color-mauve-400), var(--color-mauve-600));
+    --theme7:  light-dark(var(--color-mauve-400), var(--color-mauve-500));
+    --theme8:  light-dark(var(--color-mauve-500), var(--color-mauve-500));
+    --theme9:  light-dark(var(--color-mauve-500), var(--color-mauve-400));
+    --theme10: light-dark(var(--color-mauve-600), var(--color-mauve-300));
+    --theme11: light-dark(var(--color-mauve-700), var(--color-mauve-200));
+    --theme12: light-dark(var(--color-mauve-800), var(--color-mauve-100));
 
-    /* Accent scale — mapped to ZUI sky palette via light-dark() */
-    --accent1:  light-dark(var(--color-sky-50),  var(--color-sky-950));
-    --accent2:  light-dark(var(--color-sky-100), var(--color-sky-900));
-    --accent3:  light-dark(var(--color-sky-200), var(--color-sky-800));
-    --accent4:  light-dark(var(--color-sky-300), var(--color-sky-700));
-    --accent5:  light-dark(var(--color-sky-400), var(--color-sky-600));
-    --accent6:  light-dark(var(--color-sky-400), var(--color-sky-500));
-    --accent7:  light-dark(var(--color-sky-500), var(--color-sky-400));
-    --accent8:  light-dark(var(--color-sky-600), var(--color-sky-400));
-    --accent9:  light-dark(var(--color-sky-600), var(--color-sky-400));
-    --accent10: light-dark(var(--color-sky-700), var(--color-sky-300));
-    --accent11: light-dark(var(--color-sky-800), var(--color-sky-200));
-    --accent12: light-dark(var(--color-sky-900), var(--color-sky-100));
+    /* Accent scale — mapped to ZUI violet palette via light-dark() */
+    --accent1:  light-dark(var(--color-violet-50),  var(--color-violet-950));
+    --accent2:  light-dark(var(--color-violet-100), var(--color-violet-900));
+    --accent3:  light-dark(var(--color-violet-200), var(--color-violet-800));
+    --accent4:  light-dark(var(--color-violet-300), var(--color-violet-700));
+    --accent5:  light-dark(var(--color-violet-400), var(--color-violet-600));
+    --accent6:  light-dark(var(--color-violet-400), var(--color-violet-500));
+    --accent7:  light-dark(var(--color-violet-500), var(--color-violet-400));
+    --accent8:  light-dark(var(--color-violet-600), var(--color-violet-400));
+    --accent9:  light-dark(var(--color-violet-600), var(--color-violet-400));
+    --accent10: light-dark(var(--color-violet-700), var(--color-violet-300));
+    --accent11: light-dark(var(--color-violet-800), var(--color-violet-200));
+    --accent12: light-dark(var(--color-violet-900), var(--color-violet-100));
 
     /* Semantic aliases — point to ZUI tokens */
     --text:       var(--color-text);

--- a/packages/web/src/styles/vars.css
+++ b/packages/web/src/styles/vars.css
@@ -6,10 +6,8 @@
     --container: 1200px;
 
     /* Fonts */
-    --font-sans: Mona Sans, system-ui, sans-serif;
-    --font-mono: JetBrains Mono, SF Mono, Menlo, Monaco, Courier New, monospace;
-    --font-headings: var(--font-sans);
-    --font-body: var(--font-sans);
+    --font-sans: var(--font-body, Geist, system-ui, sans-serif);
+    --font-mono: var(--font-code, JetBrains Mono, SF Mono, Menlo, Monaco, Courier New, monospace);
 
     /* Line heights */
     --line-height-none: 1;
@@ -31,53 +29,54 @@
     /* Transitions */
     --transition: 0.2s var(--ease-in-out-4);
 
-    /* Radii */
+    /* Radii — alias ZUI tokens */
     --radii-none: 0;
-    --radii-s: 0.125rem;
-    --radii-default: 0.25rem;
-    --radii-m: 0.3rem;
-    --radii-l: 0.5rem;
-    --radii-xl: 1rem;
-    --radii-full: 9999px;
-    --radii-round: 50%;
-    --radii-pill: 9999px;
+    --radii-s: var(--radius-sm);
+    --radii-default: var(--radius-md);
+    --radii-m: var(--radius-md);
+    --radii-l: var(--radius-lg);
+    --radii-xl: var(--radius-xl);
+    --radii-full: var(--radius-full);
+    --radii-round: var(--radius-round);
+    --radii-pill: var(--radius-full);
 
-    --radius: 0.5rem; /* from shadcn */
+    /* Theme scale — mapped to ZUI mist palette via light-dark() */
+    --theme1:  light-dark(var(--color-mist-50),  var(--color-mist-950));
+    --theme2:  light-dark(var(--color-mist-100), var(--color-mist-900));
+    --theme3:  light-dark(var(--color-mist-200), var(--color-mist-800));
+    --theme4:  light-dark(var(--color-mist-300), var(--color-mist-700));
+    --theme5:  light-dark(var(--color-mist-300), var(--color-mist-700));
+    --theme6:  light-dark(var(--color-mist-400), var(--color-mist-600));
+    --theme7:  light-dark(var(--color-mist-400), var(--color-mist-500));
+    --theme8:  light-dark(var(--color-mist-500), var(--color-mist-500));
+    --theme9:  light-dark(var(--color-mist-500), var(--color-mist-400));
+    --theme10: light-dark(var(--color-mist-600), var(--color-mist-300));
+    --theme11: light-dark(var(--color-mist-700), var(--color-mist-200));
+    --theme12: light-dark(var(--color-mist-800), var(--color-mist-100));
 
-    /* Colors */
-    --theme1: var(--mauve-1);
-    --theme2: var(--mauve-2);
-    --theme3: var(--mauve-3);
-    --theme4: var(--mauve-4);
-    --theme5: var(--mauve-5);
-    --theme6: var(--mauve-6);
-    --theme7: var(--mauve-7);
-    --theme8: var(--mauve-8);
-    --theme9: var(--mauve-9);
-    --theme10: var(--mauve-10);
-    --theme11: var(--mauve-11);
-    --theme12: var(--mauve-12);
-    --accent1: var(--violet-1);
-    --accent2: var(--violet-2);
-    --accent3: var(--violet-3);
-    --accent4: var(--violet-4);
-    --accent5: var(--violet-5);
-    --accent6: var(--violet-6);
-    --accent7: var(--violet-7);
-    --accent8: var(--violet-8);
-    --accent9: var(--violet-9);
-    --accent10: var(--violet-10);
-    --accent11: var(--violet-11);
-    --accent12: var(--violet-12);
+    /* Accent scale — mapped to ZUI sky palette via light-dark() */
+    --accent1:  light-dark(var(--color-sky-50),  var(--color-sky-950));
+    --accent2:  light-dark(var(--color-sky-100), var(--color-sky-900));
+    --accent3:  light-dark(var(--color-sky-200), var(--color-sky-800));
+    --accent4:  light-dark(var(--color-sky-300), var(--color-sky-700));
+    --accent5:  light-dark(var(--color-sky-400), var(--color-sky-600));
+    --accent6:  light-dark(var(--color-sky-400), var(--color-sky-500));
+    --accent7:  light-dark(var(--color-sky-500), var(--color-sky-400));
+    --accent8:  light-dark(var(--color-sky-600), var(--color-sky-400));
+    --accent9:  light-dark(var(--color-sky-600), var(--color-sky-400));
+    --accent10: light-dark(var(--color-sky-700), var(--color-sky-300));
+    --accent11: light-dark(var(--color-sky-800), var(--color-sky-200));
+    --accent12: light-dark(var(--color-sky-900), var(--color-sky-100));
 
-    --text: var(--theme10);
-    --foreground: var(--theme12);
-    --background: var(--theme1);
-    --focus: var(--accent7);
-    --overlay: var(--overlayAlpha);
-    --border: var(--theme3);
+    /* Semantic aliases — point to ZUI tokens */
+    --text:       var(--color-text);
+    --foreground: var(--color-text);
+    --background: var(--color-background);
+    --focus:      var(--color-accent);
+    --border:     var(--color-border);
+    --overlay:    oklch(from var(--color-background) calc(l - .1) c h / 0.85);
 
     /* Other */
-    --flow-space: var(--space-m);
+    --flow-space: var(--space-md);
   }
 }

--- a/packages/web/src/styles/zui-theme.css
+++ b/packages/web/src/styles/zui-theme.css
@@ -1,0 +1,11 @@
+:root {
+  --color-theme: light-dark(var(--color-mauve-600), var(--color-mauve-400));
+  --color-accent: light-dark(var(--color-violet-600), var(--color-violet-400));
+  --color-background: light-dark(var(--color-mauve-200), var(--color-mauve-800));
+  --color-surface: light-dark(var(--color-mauve-100), var(--color-mauve-900));
+  --color-border: light-dark(var(--color-mauve-300), var(--color-mauve-700));
+  --color-text: light-dark(var(--color-mauve-700), var(--color-mauve-400));
+  --font-body: Geist, var(--font-stack-sans);
+  --font-display: Geist, var(--font-stack-sans);
+  --radius-scale: 1;
+}

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -25,10 +25,10 @@ module.exports = {
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
       borderRadius: {
-        l: 'var(--radii-l)',
-        m: 'var(--radii-m)',
-        s: 'var(--radii-s) !important',
-        xl: 'var(--radii-xl)',
+        lg: 'var(--radius-lg)',
+        md: 'var(--radius-md)',
+        sm: 'var(--radius-sm) !important',
+        xl: 'var(--radius-xl)',
       },
       colors: {
         accent: {
@@ -118,9 +118,9 @@ module.exports = {
         '3xl': 'var(--space-3xl)',
         '3xs': 'var(--space-3xs)',
         '4xs': 'var(--space-4xs)',
-        l: 'var(--space-l)',
-        m: 'var(--space-m)',
-        s: 'var(--space-s)',
+        l: 'var(--space-lg)',
+        m: 'var(--space-md)',
+        s: 'var(--space-sm)',
         xl: 'var(--space-xl)',
         xs: 'var(--space-xs)',
       },

--- a/packages/web/worker/ai/summarise.ts
+++ b/packages/web/worker/ai/summarise.ts
@@ -1,12 +1,16 @@
 export const MAX_CONTENT_LENGTH = 24_000
 
-export const summariseSystemPrompt = `You are an article summariser. You will be given the text content of a web page and you should produce a concise summary in markdown format.
+export const summariseSystemPrompt = `You are a personal reading assistant. You will be given the text content of a web page and should produce a concise summary in markdown format.
 
-Start with a brief 2-3 sentence summary paragraph, then list the key takeaways as bullet points.
+If the page content is not summarisable (e.g. a login wall, error page, or cookie/navigation text with no meaningful content), respond only with: "This page doesn't contain summarisable content."
+
+Otherwise, structure your summary as follows:
+1. A 2–3 sentence paragraph covering what the page is about and why it matters
+2. Bullet points covering key details, facts, or takeaways not already covered in the paragraph — use **bold** to emphasise important terms or figures where helpful
 
 Rules:
-- Only include the summary, nothing extra (no preamble like "Here is a summary")
-- Be concise and focus on the most important points
-- Use markdown formatting
+- No preamble or closing remarks — output the summary only
+- The paragraph and bullets should complement each other, not repeat the same information
+- Cut through vague or promotional language and prioritise concrete facts
 - Keep the total summary under 300 words
-- If the content is too short or not an article, just summarise what's there`
+- Use plain English`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@mrmartineau/xtractr':
         specifier: ^0.2.7
         version: 0.2.7
+      '@mrmartineau/zui':
+        specifier: ^0.7.0
+        version: 0.7.0(react@19.2.4)(typescript@5.9.3)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1882,6 +1885,24 @@ packages:
 
   '@mrmartineau/xtractr@0.2.7':
     resolution: {integrity: sha512-S+SJjPTb2chokQlYDxydKlwt1wPJTIsltTqllWbWFYhLfZ7YUj8Yb85RxCDhxh19z8W7E7rU/kD78R9hg9GXSg==}
+
+  '@mrmartineau/zui@0.7.0':
+    resolution: {integrity: sha512-+UzLegKztFx8tBqpT6KapWN9NEEhRIJU873GM7XAiNK32OOi283Dtd7ITMMpbgoop+JnGgSRdOqKk+nUQra8sQ==}
+    hasBin: true
+    peerDependencies:
+      astro: '*'
+      react: ^18.0.0 || ^19.0.0
+      solid-js: ^1.7.0
+      vue: ^3.3.0
+    peerDependenciesMeta:
+      astro:
+        optional: true
+      react:
+        optional: true
+      solid-js:
+        optional: true
+      vue:
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -4137,6 +4158,14 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cva@1.0.0-beta.4:
+    resolution: {integrity: sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==}
+    peerDependencies:
+      typescript: '>= 4.5.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
@@ -8798,6 +8827,14 @@ snapshots:
     transitivePeerDependencies:
       - canvas
 
+  '@mrmartineau/zui@0.7.0(react@19.2.4)(typescript@5.9.3)':
+    dependencies:
+      cva: 1.0.0-beta.4(typescript@5.9.3)
+    optionalDependencies:
+      react: 19.2.4
+    transitivePeerDependencies:
+      - typescript
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.9.0
@@ -11118,6 +11155,12 @@ snapshots:
       lru-cache: 11.2.6
 
   csstype@3.2.3: {}
+
+  cva@1.0.0-beta.4(typescript@5.9.3):
+    dependencies:
+      clsx: 2.1.1
+    optionalDependencies:
+      typescript: 5.9.3
 
   data-uri-to-buffer@6.0.2: {}
 


### PR DESCRIPTION
## Summary

- Installs `@mrmartineau/zui` and imports ZUI CSS in `globals.css`
- Migrates **Button** to `zui-button` base class with ZUI variant/size classes; Otter-specific variants (`nav`, `cmdk`, `collapsible`) keep their custom CSS
- Migrates **Input** and **Textarea** to `zui-input` / `zui-textarea`
- Migrates **Label** to `zui-label`, dropping the Radix Label dependency
- Migrates **Link** default and accent variants to `zui-link`; all other variants (`sidebar`, `tag`, `logo`, `fab`, `feedTitle`, `add`) keep their custom CSS
- Migrates **Dialog** content structure to use ZUI dialog CSS classes (`zui-dialog`, `zui-dialog-header`, `zui-dialog-title`, `zui-dialog-description`, `zui-dialog-body`) while keeping Radix for portal/overlay/trigger/close behaviour and preserving placement variants

## Not in scope (follow-up)

- Text, Code, Badge, Card, Tooltip, Prose — lower risk, deferred
- Full token remap for legacy components — unmigrated components still use Otter's existing vars
- Radix Select, Popover, Combobox, Tooltip — kept intentionally (ZUI doesn't match their functionality)

## Test plan

- [ ] Verify Button variants render correctly (default, ghost, outline, secondary, destructive, nav, cmdk, collapsible, icon)
- [ ] Verify Input, Textarea, Label styling
- [ ] Verify Link default/accent use ZUI style; sidebar/tag/etc. unchanged
- [ ] Verify Dialog opens/closes correctly with title, description, and body content
- [ ] Check dark mode

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate core components and design tokens to ZUI for consistent styling and less custom CSS. Adds `@mrmartineau/zui`, updates base components, and moves Markdown, CodeBlock, Card, focus ring, and theme tokens to ZUI.

- **Refactors**
  - Components: Button now uses `zui-button` and ZUI size/variant classes; keeps `nav` and `collapsible` (the `cmdk` style is now a CSS helper on a ZUI Button). Input/Textarea use `zui-input`/`zui-textarea`. Label uses `zui-label`. Link default/accent use `zui-link`; other variants (`sidebar`, `tag`, `logo`, `fab`, etc.) keep app CSS. Dialog uses ZUI `zui-dialog-*` sections; Radix behavior unchanged. Markdown uses `prose`. CodeBlock uses `zui-pre`/`zui-code`. Card moves to ZUI surface/border tokens and radius/space vars. CmdK, Collapsible, Feed, and bookmark read views now use the ZUI React `Button`.
  - Styles/tokens: Add `src/styles/zui-theme.css` and import ZUI CSS in `globals.css`. Remap `--theme1-12` to ZUI mauve and `--accent1-12` to ZUI violet via `light-dark()`. Alias semantic colors and radii to ZUI tokens; replace focus ring with ZUI `--focus-ring`/`--focus-ring-offset`. Update Tailwind radius/spacing aliases to new `--radius-*`/`--space-*` vars; move several component styles under `@layer zui.components`.
  - Worker: Improve summariser prompt to detect non-summarisable pages and produce a clearer paragraph + bullets output.

- **Dependencies**
  - Adds `@mrmartineau/zui` to `packages/web`.

<sup>Written for commit 28a439df3f63eb599cbbe2a3e6612fe4f20c693a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

