### PR TITLE
refactor(web): per-request pg Client with Hyperdrive

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,28 @@
+name: Security
+
+on:
+  push:
+    branches: ['**']
+
+jobs:
+  safe-chain:
+    name: Aikido safe-chain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+.env
+.env.local
+.dev.vars
+.mcp.json

--- a/packages/web/auth/server.ts
+++ b/packages/web/auth/server.ts
@@ -3,7 +3,8 @@ import { compare, hash } from 'bcryptjs'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { betterAuth } from 'better-auth/minimal'
 import { jwt } from 'better-auth/plugins'
-import { createDb, type DbEnv } from '../db/client'
+import type { Db } from '../db/client'
+import type { DbEnv } from '../db/client'
 import {
   authAccounts,
   authJwks,
@@ -49,9 +50,7 @@ const getTrustedOAuthClients = (env: AuthEnv) =>
     ? new Set([env.RAYCAST_OAUTH_CLIENT_ID])
     : undefined
 
-export const createAuth = (env: AuthEnv) => {
-  const db = createDb(env)
-
+export const createAuth = (env: AuthEnv, db: Db) => {
   return betterAuth({
     advanced: {
       database: {

--- a/packages/web/db/client.ts
+++ b/packages/web/db/client.ts
@@ -1,8 +1,8 @@
-import { drizzle } from 'drizzle-orm/node-postgres'
-import { Pool } from 'pg'
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres'
+import { Client } from 'pg'
 import * as schema from './schema'
 
-export type Db = ReturnType<typeof createDb>
+export type Db = NodePgDatabase<typeof schema>
 
 export type HyperdriveBinding = {
   connectionString: string
@@ -23,10 +23,8 @@ export const getDatabaseUrl = (env: DbEnv) => {
   return databaseUrl
 }
 
-export const createDb = (env: DbEnv) => {
-  const pool = new Pool({
-    connectionString: getDatabaseUrl(env),
-  })
-
-  return drizzle(pool, { schema })
+export const createDbClient = (env: DbEnv) => {
+  const client = new Client({ connectionString: getDatabaseUrl(env) })
+  const db = drizzle(client, { schema })
+  return { client, db }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -110,6 +110,7 @@
     "wrangler": "catalog:"
   },
   "name": "@mrmartineau/otter-web",
+  "packageManager": "pnpm@11.1.1",
   "private": true,
   "scripts": {
     "build": "tsc -b && vite build",
@@ -119,7 +120,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "deploy": "pnpm run build && wrangler deploy",
-    "dev": "vite --port 5678",
+    "dev": "portless otter vite",
     "oauth:raycast": "tsx scripts/upsert-raycast-oauth-client.ts",
     "preview": "pnpm run build && vite preview",
     "type-check": "tsc --noEmit"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -111,6 +111,7 @@
   },
   "name": "@mrmartineau/otter-web",
   "packageManager": "pnpm@11.1.1",
+  "portless": "otter",
   "private": true,
   "scripts": {
     "build": "tsc -b && vite build",
@@ -120,7 +121,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "deploy": "pnpm run build && wrangler deploy",
-    "dev": "portless otter vite",
+    "dev": "portless run vite",
     "oauth:raycast": "tsx scripts/upsert-raycast-oauth-client.ts",
     "preview": "pnpm run build && vite preview",
     "type-check": "tsc --noEmit"

--- a/packages/web/worker/bluesky/sendBlueskyPost.ts
+++ b/packages/web/worker/bluesky/sendBlueskyPost.ts
@@ -4,9 +4,9 @@ import { eq } from 'drizzle-orm'
 import type { Context } from 'hono'
 import { errorResponse } from '@/utils/fetching/errorResponse'
 import { filteredTags } from '@/utils/filteredTags'
-import { createDb } from '../../db/client'
 import { bookmarks, userIntegrations } from '../../db/schema'
 import type { WorkerEnv } from '../env'
+import '../middleware/db'
 
 type HonoContext = Context<{ Bindings: WorkerEnv }>
 
@@ -52,7 +52,7 @@ export const sendBlueskyPost = async (context: HonoContext) => {
   }
 
   // Fetch the user's Bluesky integration settings
-  const db = createDb(context.env)
+  const db = context.var.db
   const integration = await db.query.userIntegrations.findFirst({
     where: eq(userIntegrations.userId, body.record.user),
   })

--- a/packages/web/worker/bookmarks/getRecentPublicBookmarks.ts
+++ b/packages/web/worker/bookmarks/getRecentPublicBookmarks.ts
@@ -1,12 +1,12 @@
 import { and, count, desc, eq } from 'drizzle-orm'
-import type { HonoRequest } from 'hono'
+import type { Context } from 'hono'
 import { API_HEADERS, DEFAULT_API_RESPONSE_LIMIT } from '@/constants'
 import { apiResponseGenerator } from '@/utils/fetching/apiResponse'
 import { getErrorMessage } from '@/utils/get-error-message'
 import { searchParamsToObject } from '@/utils/searchParamsToObject'
-import { createDb } from '../../db/client'
 import { bookmarks } from '../../db/schema'
 import type { WorkerEnv } from '../env'
+import '../middleware/db'
 import { bookmarkToRow } from './mapper'
 
 /**
@@ -15,15 +15,15 @@ import { bookmarkToRow } from './mapper'
  * No authentication required.
  */
 export const getRecentPublicBookmarks = async (
-  request: HonoRequest<'/api/recent'>,
-  env: WorkerEnv,
+  context: Context<{ Bindings: WorkerEnv }>,
 ) => {
+  const request = context.req
   try {
     const searchParams = searchParamsToObject(request.url)
     const limit = Number(searchParams.limit) || DEFAULT_API_RESPONSE_LIMIT
     const offset = Number(searchParams.offset) || 0
 
-    const db = createDb(env)
+    const db = context.var.db
     const where = and(
       eq(bookmarks.public, true),
       eq(bookmarks.status, 'active'),

--- a/packages/web/worker/context.ts
+++ b/packages/web/worker/context.ts
@@ -2,11 +2,12 @@ import { eq } from 'drizzle-orm'
 import type { Context, HonoRequest } from 'hono'
 import { createLocalJWKSet, jwtVerify, type JWK, type JWTPayload } from 'jose'
 import { createAuth, getOAuthAudience } from '../auth/server'
-import { createDb, type Db } from '../db/client'
+import type { Db } from '../db/client'
 import { profiles } from '../db/schema'
 import type { UserProfile } from '../src/types/db'
 import { errorResponse } from '../src/utils/fetching/errorResponse'
 import type { WorkerEnv } from './env'
+import '../worker/middleware/db'
 
 export type RequestContext = {
   db: Db
@@ -126,8 +127,8 @@ export const createRequestContext = async (
   context: Context<{ Bindings: WorkerEnv }>,
   scopes: string[] = [],
 ): Promise<RequestContext> => {
-  const db = createDb(context.env)
-  const auth = createAuth(context.env)
+  const db = context.var.db
+  const auth = createAuth(context.env, db)
   const session = await auth.api.getSession({
     headers: context.req.raw.headers,
   })

--- a/packages/web/worker/hono.ts
+++ b/packages/web/worker/hono.ts
@@ -114,7 +114,15 @@ api.post('/ai/classify', async (context) => {
 })
 api.get('/rss', async (c) => {
   const feed = c.req.query('feed')
-  const isValidUrl = new URL(feed ?? '')
+  let isValidUrl = false
+  if (feed) {
+    try {
+      new URL(feed)
+      isValidUrl = true
+    } catch {
+      isValidUrl = false
+    }
+  }
 
   if (isValidUrl && feed) {
     const jsonFeed = await feedToJson(feed)

--- a/packages/web/worker/hono.ts
+++ b/packages/web/worker/hono.ts
@@ -1,7 +1,6 @@
 import { Hono } from 'hono'
 
 import { createAuth } from '../auth/server'
-import { dbMiddleware } from './middleware/db'
 import { classifyBookmark } from './ai/classify'
 import { descriptionSystemPrompt } from './ai/description'
 import { generateResponse } from './ai/generateResponse'
@@ -47,6 +46,7 @@ import {
   getTags,
   renameTag,
 } from './meta'
+import { dbMiddleware } from './middleware/db'
 import { getCurrentProfile, updateCurrentProfile } from './profile'
 import { feedToJson } from './rss/rss-to-json'
 import { handleScrapeContent } from './scraper/scrape-content'
@@ -63,13 +63,75 @@ import { sendToots } from './toots/sendToots'
 
 export const api = new Hono<{ Bindings: WorkerEnv }>()
 
-api.use('*', dbMiddleware)
-
+// Routes that do not touch the database — declared before dbMiddleware
+// so they skip the per-request Postgres connection.
 api.get('/', (c) => {
   return c.text('Otter API', 200)
 })
+api.get('/scrape', async (c) => {
+  return await handleScrapeContent(c.req)
+})
+api.get('/scrape-content', async (c) => {
+  return await handleScrapeContent(c.req)
+})
+api.post('/ai/title', async (context) => {
+  const { prompt } = await context.req.json()
+  return await generateResponse({
+    context,
+    prompt,
+    systemPrompt: titleSystemPrompt,
+  })
+})
+api.post('/ai/description', async (context) => {
+  const { title, prompt } = await context.req.json()
+  return await generateResponse({
+    context,
+    prompt,
+    systemPrompt: descriptionSystemPrompt(title),
+  })
+})
+api.post('/ai/summarise', async (context) => {
+  const { prompt } = await context.req.json()
+  const truncated = prompt.slice(0, MAX_CONTENT_LENGTH)
+  return await generateResponse({
+    context,
+    prompt: truncated,
+    systemPrompt: summariseSystemPrompt,
+  })
+})
+api.post('/ai/classify', async (context) => {
+  const { title, description, url, tags, currentType } =
+    await context.req.json()
+  const result = await classifyBookmark({
+    context,
+    currentType: currentType ?? 'link',
+    description: description ?? '',
+    existingTags: tags ?? [],
+    title: title ?? '',
+    url: url ?? '',
+  })
+  return context.json(result)
+})
+api.get('/rss', async (c) => {
+  const feed = c.req.query('feed')
+  const isValidUrl = new URL(feed ?? '')
 
-api.on(["GET", "POST"], '/auth/*', async (c) => {
+  if (isValidUrl && feed) {
+    const jsonFeed = await feedToJson(feed)
+    return c.json(jsonFeed)
+  }
+
+  return c.json(
+    {
+      error: 'Feed not found',
+    },
+    404,
+  )
+})
+
+api.use('*', dbMiddleware)
+
+api.on(['GET', 'POST'], '/auth/*', async (c) => {
   return await createAuth(c.env, c.var.db).handler(c.req.raw)
 })
 api.get('/me', async (c) => {
@@ -181,50 +243,6 @@ api.post('/toot', async (c) => {
 api.post('/bluesky', async (c) => {
   return await sendBlueskyPost(c)
 })
-api.get('/scrape', async (c) => {
-  return await handleScrapeContent(c.req)
-})
-api.get('/scrape-content', async (c) => {
-  return await handleScrapeContent(c.req)
-})
-api.post('/ai/title', async (context) => {
-  const { prompt } = await context.req.json()
-  return await generateResponse({
-    context,
-    prompt,
-    systemPrompt: titleSystemPrompt,
-  })
-})
-api.post('/ai/description', async (context) => {
-  const { title, prompt } = await context.req.json()
-  return await generateResponse({
-    context,
-    prompt,
-    systemPrompt: descriptionSystemPrompt(title),
-  })
-})
-api.post('/ai/summarise', async (context) => {
-  const { prompt } = await context.req.json()
-  const truncated = prompt.slice(0, MAX_CONTENT_LENGTH)
-  return await generateResponse({
-    context,
-    prompt: truncated,
-    systemPrompt: summariseSystemPrompt,
-  })
-})
-api.post('/ai/classify', async (context) => {
-  const { title, description, url, tags, currentType } =
-    await context.req.json()
-  const result = await classifyBookmark({
-    context,
-    currentType: currentType ?? 'link',
-    description: description ?? '',
-    existingTags: tags ?? [],
-    title: title ?? '',
-    url: url ?? '',
-  })
-  return context.json(result)
-})
 api.post('/mcp', async (c) => {
   return await handleMcpPost(c)
 })
@@ -236,22 +254,6 @@ api.delete('/mcp', (c) => {
 })
 api.options('/mcp', (c) => {
   return handleMcpOptions(c)
-})
-api.get('/rss', async (c) => {
-  const feed = c.req.query('feed')
-  const isValidUrl = new URL(feed ?? '')
-
-  if (isValidUrl && feed) {
-    const jsonFeed = await feedToJson(feed)
-    return c.json(jsonFeed)
-  }
-
-  return c.json(
-    {
-      error: 'Feed not found',
-    },
-    404,
-  )
 })
 
 export const app = new Hono<{ Bindings: WorkerEnv }>()

--- a/packages/web/worker/hono.ts
+++ b/packages/web/worker/hono.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 
 import { createAuth } from '../auth/server'
+import { dbMiddleware } from './middleware/db'
 import { classifyBookmark } from './ai/classify'
 import { descriptionSystemPrompt } from './ai/description'
 import { generateResponse } from './ai/generateResponse'
@@ -62,12 +63,14 @@ import { sendToots } from './toots/sendToots'
 
 export const api = new Hono<{ Bindings: WorkerEnv }>()
 
+api.use('*', dbMiddleware)
+
 api.get('/', (c) => {
   return c.text('Otter API', 200)
 })
 
 api.on(["GET", "POST"], '/auth/*', async (c) => {
-  return await createAuth(c.env).handler(c.req.raw)
+  return await createAuth(c.env, c.var.db).handler(c.req.raw)
 })
 api.get('/me', async (c) => {
   return await getCurrentProfile(c)
@@ -104,7 +107,7 @@ api.get('/check-url', async (c) => {
   return await checkBookmarkUrl(c)
 })
 api.get('/recent', async (c) => {
-  return await getRecentPublicBookmarks(c.req, c.env)
+  return await getRecentPublicBookmarks(c)
 })
 api.get('/search', async (c) => {
   return await getSearch(c)
@@ -253,11 +256,12 @@ api.get('/rss', async (c) => {
 
 export const app = new Hono<{ Bindings: WorkerEnv }>()
 
+app.use('/.well-known/*', dbMiddleware)
 app.all('/.well-known/oauth-authorization-server/api/auth', async (c) => {
-  return await createAuth(c.env).handler(c.req.raw)
+  return await createAuth(c.env, c.var.db).handler(c.req.raw)
 })
 app.all('/.well-known/openid-configuration/api/auth', async (c) => {
-  return await createAuth(c.env).handler(c.req.raw)
+  return await createAuth(c.env, c.var.db).handler(c.req.raw)
 })
 app.route('/api', api)
 

--- a/packages/web/worker/middleware/db.ts
+++ b/packages/web/worker/middleware/db.ts
@@ -1,0 +1,22 @@
+import { createMiddleware } from 'hono/factory'
+import { createDbClient, type Db } from '../../db/client'
+import type { WorkerEnv } from '../env'
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    db: Db
+  }
+}
+
+export const dbMiddleware = createMiddleware<{
+  Bindings: WorkerEnv
+}>(async (c, next) => {
+  const { client, db } = createDbClient(c.env)
+  await client.connect()
+  c.set('db', db)
+  try {
+    await next()
+  } finally {
+    c.executionCtx.waitUntil(client.end().catch(() => {}))
+  }
+})

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -4,7 +4,6 @@
  */
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-
   /**
    * Bindings
    * Bindings allow your Worker to interact with resources on the Cloudflare Developer Platform, including
@@ -22,6 +21,12 @@
   },
   "compatibility_date": "2025-07-26",
   "compatibility_flags": ["nodejs_compat"],
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "fb72d6282a264b2e9f59a42e010bff2f"
+    }
+  ],
   "keep_vars": true,
   "main": "worker/index.ts",
   "name": "otter-web",
@@ -40,13 +45,13 @@
       "persist": true
     }
   },
-
   /**
    * Smart Placement
    * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
    */
-  "placement": { "mode": "smart" },
-
+  "placement": {
+    "mode": "smart"
+  },
   /* Custom domain */
   "routes": [
     {
@@ -66,13 +71,11 @@
    * Note: Use secrets to store sensitive data.
    * https://developers.cloudflare.com/workers/configuration/secrets/
    */
-
   /**
    * Static Assets
    * https://developers.cloudflare.com/workers/static-assets/binding/
    */
   // "assets": { "directory": "./public/", "binding": "ASSETS" },
-
   /**
    * Service Bindings (communicate between multiple Workers)
    * https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 0.19.3
       '@better-auth/oauth-provider':
         specifier: ^1.6.9
-        version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))
+        version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))
       '@dnd-kit/abstract':
         specifier: ^0.1.21
         version: 0.1.21
@@ -192,7 +192,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
+        version: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
       change-case:
         specifier: ^5.4.4
         version: 5.4.4
@@ -213,7 +213,7 @@ importers:
         version: 0.13.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
       email-validator:
         specifier: ^2.0.4
         version: 2.0.4
@@ -2408,6 +2408,10 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@neondatabase/serverless@1.1.0':
+    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
+    engines: {node: '>=19.0.0'}
 
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
@@ -10316,12 +10320,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260313.1
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))':
+  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))':
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
 
   '@better-auth/kysely-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
     dependencies:
@@ -10340,12 +10344,12 @@ snapshots:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/oauth-provider@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))':
+  '@better-auth/oauth-provider@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
+      better-auth: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
       better-call: 1.3.5(zod@4.3.6)
       jose: 6.2.3
       zod: 4.3.6
@@ -11781,6 +11785,9 @@ snapshots:
       '@emnapi/core': 1.9.0
       '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@neondatabase/serverless@1.1.0':
     optional: true
 
   '@noble/ciphers@2.2.0': {}
@@ -13399,7 +13406,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 20.19.39
+      '@types/node': 25.5.0
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -13466,7 +13473,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 25.5.0
 
   '@types/lodash.throttle@4.1.9':
     dependencies:
@@ -13529,7 +13536,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 25.5.0
 
   '@types/semver@7.7.1': {}
 
@@ -13562,7 +13569,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 25.5.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
@@ -14103,10 +14110,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)):
+  better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))
+      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))
       '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
       '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -14124,7 +14131,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
       pg: 8.20.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -14915,9 +14922,10 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260313.1
+      '@neondatabase/serverless': 1.1.0
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.20.0
       kysely: 0.28.16

--- a/solo.yml
+++ b/solo.yml
@@ -1,6 +1,13 @@
 name: otter
 icon: null
 processes:
+  hunk diff:
+    command: hunk diff --watch
+    working_dir: null
+    auto_start: true
+    auto_restart: true
+    restart_when_changed: []
+    env: {}
   web:dev:
     command: nr web:dev
     working_dir: null


### PR DESCRIPTION
## Summary
- Swap Drizzle's `pg.Pool` for a per-request `pg.Client`, owned by a new `dbMiddleware` (`connect()` on entry, `client.end()` via `waitUntil` on exit). `Pool` doesn't fit Workers isolates and double-pools on top of Hyperdrive.
- `createAuth(env, db)` now takes the shared client instead of creating its own — one Postgres connection per request instead of two.
- Augment Hono's `ContextVariableMap` so `c.var.db` is typed everywhere without per-file annotations.
- Remove `console.info` lines that printed the Hyperdrive connection string and `DATABASE_URL` (credential leak).
- Add Hyperdrive binding in `wrangler.jsonc`.

## Test plan
- [ ] `pnpm exec tsc -b` clean (verified locally)
- [ ] `wrangler dev` boots with `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE` set
- [ ] Auth: sign in, session persists, `/api/auth/*` works
- [ ] `/api/recent` returns bookmarks
- [ ] `/api/bluesky` webhook still posts (integration path)
- [ ] No connection-leak warnings in worker logs under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor DB access to a per-request `pg.Client` via `Hono` middleware on Cloudflare Hyperdrive for safer, leaner connections. Scope the DB middleware to only DB-backed routes, harden `/rss` URL validation, and add a CI security check with Aikido `safe-chain`.

- **Refactors**
  - Replace `pg.Pool` with per-request `pg.Client` via `createDbClient`; middleware connects, exposes `c.var.db`, and closes with `executionCtx.waitUntil(client.end())`.
  - Scope `dbMiddleware` so `/`, `/scrape*`, `/ai/*`, and `/rss` skip DB; `.well-known/*` and API routes use it. Strengthen `/rss` to validate URLs and return 404 on bad input.
  - Share one DB client with auth: `createAuth(env, db)`; handlers read `c.var.db` (recent bookmarks, Bluesky webhook).
  - Remove logs that printed connection strings.

- **Migration**
  - Hyperdrive binding `HYPERDRIVE` is now in `wrangler.jsonc` (update the ID per environment if needed).
  - For local dev, set `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE`.
  - Handlers now read `db` from `c.var`.
  - Dev script uses `portless run vite` (`pnpm dev`).

<sup>Written for commit 6d8523aca964ea5ddf37f1dc6bf586000d0b9a90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

