### PR TITLE
feat(web): type public share infinite query options

### DIFF
--- a/packages/web/src/utils/fetching/shares.ts
+++ b/packages/web/src/utils/fetching/shares.ts
@@ -1,4 +1,5 @@
 import {
+  type InfiniteData,
   infiniteQueryOptions,
   queryOptions,
   useMutation,
@@ -120,7 +121,13 @@ const fetchPublicShare = async ({
 
 export const getPublicShareInfiniteOptions = (token: string) => {
   const limit = DEFAULT_API_RESPONSE_LIMIT
-  return infiniteQueryOptions({
+  return infiniteQueryOptions<
+    PublicShareResponse,
+    Error,
+    InfiniteData<PublicShareResponse, number>,
+    ['public-share', string],
+    number
+  >({
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
       const total = lastPage.count ?? 0
       const nextOffset = lastPageParam + limit


### PR DESCRIPTION
## Summary
- `infiniteQueryOptions` for the public share page failed type inference because `getNextPageParam` precedes `queryFn` in the object literal, leaving page data typed as `unknown`.
- Pass explicit generics to `infiniteQueryOptions` so `share.$token.tsx` and `shares.ts` are properly typed.

## Test plan
- [x] `tsc -b` passes with no errors
- [x] `/share/:token` page renders and paginates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes type inference for the public share infinite query by adding explicit generics to `infiniteQueryOptions`. Restores correct page types and clears TS errors in `share.$token.tsx` and `shares.ts`.

- **Bug Fixes**
  - Typed `getPublicShareInfiniteOptions` with `<PublicShareResponse, Error, InfiniteData<PublicShareResponse, number>, ['public-share', string], number>`.
  - Imported `InfiniteData` and aligned `getNextPageParam`/`queryFn` types so pages are no longer `unknown`.

<sup>Written for commit 571769b8a4a7d0919f95ec9ec9aec9b53b510b9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

