### PR TITLE
ci: add Cloudflare Workers preview deployments for web PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,73 @@ jobs:
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - run: pnpm install --frozen-lockfile
       - run: pnpm run web:build
+
+  preview:
+    name: Preview Deployment
+    needs: build
+    runs-on: ubuntu-latest
+    # Skip on forked PRs: they cannot access the Cloudflare secrets.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      - run: pnpm install --frozen-lockfile
+      - name: Build site
+        run: pnpm web:build
+      - name: Upload preview version to Cloudflare
+        id: preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/web
+          command: versions upload
+      - name: Comment preview URL on PR
+        if: steps.preview.outputs['deployment-url'] != ''
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs['deployment-url'] }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL
+            const marker = '<!-- otter-web-preview -->'
+            const body = [
+              marker,
+              '### Otter Web preview',
+              '',
+              `Preview deployment for this PR: ${url}`,
+              '',
+              'Note: this version is uploaded with 0% traffic, so production is unaffected. It shares the production database, secrets and `BETTER_AUTH_URL`, so auth flows may not behave correctly on the preview URL.',
+            ].join('\n')
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const existing = comments.find(
+              (comment) => comment.body && comment.body.includes(marker),
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              })
+            }


### PR DESCRIPTION
## Summary

Adds per-PR **Cloudflare Workers preview deployments** for the `packages/web` Worker (`otter-web`). Previously the `PR Build` workflow only built the site and never deployed anything, so there was no way to preview a PR.

A new `preview` job in `.github/workflows/ci.yml`:
- runs after the `build` job passes
- builds the web package and runs `wrangler versions upload`
- comments the generated `workers.dev` preview URL on the PR (sticky comment — updated in place on each push)

Production is unaffected: `versions upload` creates a version with **0% traffic**, unlike `wrangler deploy`.

This is scoped to the **web package only** — it uses `pnpm web:build` and `workingDirectory: packages/web`.

## Manual steps still required (not code)

These cannot be done in the repo and must be done once by the maintainer:

1. **Cloudflare dashboard** → Workers & Pages → `otter-web` → Settings → Domains & Routes → **enable "Preview URLs"**. The account also needs a `workers.dev` subdomain registered. No DNS changes are needed — preview URLs are served on `*.workers.dev`.
2. Confirm the `CLOUDFLARE_API_TOKEN` repo secret has `Workers Scripts: Edit` (it already does, since `deploy.yml` works).

## Known limitations

- **Auth**: `BETTER_AUTH_URL` is hardcoded to `https://otter.zander.wtf` in `wrangler.jsonc`. Better Auth validates the request origin, so login/session flows will not work correctly on a preview URL. Previews are suitable for visual/UI review.
- **Database**: previews share the production Neon database (same Hyperdrive binding and secrets). Anything a preview writes goes to production data.
- Forked PRs are skipped — they cannot access the Cloudflare secrets.

## Test plan

- [ ] Open a PR from a branch in this repo and confirm the `Preview Deployment` job runs and succeeds
- [ ] Confirm a comment with a `workers.dev` preview URL is posted on the PR
- [ ] Confirm the preview URL loads the app
- [ ] Confirm production `otter.zander.wtf` is unchanged after a preview upload
- [ ] Push another commit and confirm the existing comment is updated rather than duplicated

https://claude.ai/code/session_017cfUCg5FvYQMjPYHpYwN1B

---
_Generated by [Claude Code](https://claude.ai/code/session_017cfUCg5FvYQMjPYHpYwN1B)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-PR Cloudflare Workers previews for the web Worker so each PR gets a live `workers.dev` URL. Uploads with 0% traffic to keep production safe; previews share prod data and auth may not work.

- **New Features**
  - Adds a `preview` job that runs after build, builds `packages/web`, runs `wrangler versions upload` via `cloudflare/wrangler-action`, and posts a sticky preview URL on the PR.
  - Skips forked PRs and only targets `packages/web` using `pnpm web:build`.

- **Migration**
  - In Cloudflare, enable Preview URLs for `otter-web` and ensure a `workers.dev` subdomain exists.
  - Confirm `CLOUDFLARE_API_TOKEN` has “Workers Scripts: Edit” permissions.

<sup>Written for commit ee94bc0b48aa5fe85c968aa72a6c12255cc16ee0. Summary will update on new commits. <a href="https://cubic.dev/pr/mrmartineau/Otter/pull/23?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

