### PR TITLE
fix(web): stale feed data and broken trash button

### DIFF
--- a/packages/web/src/components/FeedItemActions.tsx
+++ b/packages/web/src/components/FeedItemActions.tsx
@@ -250,7 +250,10 @@ export const FeedItemActions = ({
                 onClick={() => {
                   dropdownItemClicked.current = true
                   playSwitchOn()
-                  handleArchiveBookmark()
+                  // Defer so the dropdown finishes closing before
+                  // window.confirm opens — a synchronous confirm fired into
+                  // Radix's menu teardown gets auto-dismissed (returns false).
+                  setTimeout(handleArchiveBookmark, 0)
                 }}
               >
                 Trash

--- a/packages/web/src/constants.ts
+++ b/packages/web/src/constants.ts
@@ -111,6 +111,7 @@ export const API_TWEETS_SEARCH = '/api/search/tweets'
 export const API_HEADERS = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'no-store',
   'Content-Type': 'application/json',
 }
 

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -24,7 +24,13 @@
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",
-      "id": "fb72d6282a264b2e9f59a42e010bff2f"
+      "id": "fb72d6282a264b2e9f59a42e010bff2f",
+      // Disable query result caching: this app expects edits to be
+      // visible immediately. Hyperdrive caching is time-based only and
+      // does not invalidate on writes, so it served stale reads for ~60s.
+      "caching": {
+        "disabled": true
+      }
     }
   ],
   "keep_vars": true,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - packages/*
 
+allowBuilds:
+  electron: false
+
 catalog:
   '@cloudflare/vite-plugin': ^1.28.0
   '@cloudflare/workers-types': ^4.20260313.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@ packages:
 
 allowBuilds:
   electron: false
+  esbuild: true
+  sharp: false
+  workerd: true
 
 catalog:
   '@cloudflare/vite-plugin': ^1.28.0


### PR DESCRIPTION
## Problem

Two reported symptoms, three root causes — all about edits not reaching the UI.

### 1. Edits take ~60s to appear
React Query invalidation is correct (every edit path invalidates `['bookmarks']`). The stale data came from **Hyperdrive query caching**, which is enabled by default and is **time-based only** — it does not invalidate on writes. After an `UPDATE`, the feed's `SELECT` was served from Hyperdrive's cache (default `max_age` 60s + 15s SWR).

### 2. Trash button does nothing — no API call
The feed "Trash" item is a Radix `DropdownMenu.Item`. A synchronous `window.confirm()` fired from it is auto-dismissed during the menu's close/focus teardown, returning `false`, so `updateBookmark` (the PATCH) never ran. The trash-page "Permanently delete" button uses the same `confirm` but works — because it's a plain `<Button>`, not a menu item.

## Changes

- **`wrangler.jsonc`** — disable Hyperdrive query caching (`caching.disabled`). Connection pooling is unaffected.
- **`constants.ts`** — add `Cache-Control: no-store` to `API_HEADERS` so browser/CDN heuristic caching can't add lag.
- **`FeedItemActions.tsx`** — defer `handleArchiveBookmark` with `setTimeout(…, 0)` so the dropdown finishes closing before `window.confirm` opens.

## Notes

- Verified separately: all bookmark feed queries correctly filter `status = 'active'`; trash is the only `inactive` view. No trash leak.
- Follow-up worth considering: replace `window.confirm` with a Radix `AlertDialog` for consistent styling and no native-dialog races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale feed data and the broken Trash action in the feed. Edits now show immediately, and delete requests fire reliably.

- **Bug Fixes**
  - Disabled `Hyperdrive` query caching in `packages/web/wrangler.jsonc` and added `Cache-Control: no-store` in `API_HEADERS` to prevent stale reads.
  - Deferred the Trash handler in `FeedItemActions.tsx` with `setTimeout(…, 0)` so `window.confirm` runs after the dropdown closes.
  - Updated `pnpm-workspace.yaml` `allowBuilds` approvals to pass CI: `electron: false`, `esbuild: true`, `sharp: false`, `workerd: true`.

<sup>Written for commit aa17ce497c1a519211d8e2ca8e937e49447f84b5. Summary will update on new commits. <a href="https://cubic.dev/pr/mrmartineau/Otter/pull/24?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

