### PR TITLE
fix(web): derive collections from any tag prefix

### DIFF
--- a/packages/web/worker/collections.ts
+++ b/packages/web/worker/collections.ts
@@ -1,0 +1,54 @@
+import type { CollectionType } from '@/utils/fetching/meta'
+
+type TaggedRow = { tags: string[] | null }
+
+// A collection is the prefix of any tag formatted `<name>:<rest>`.
+// `ai:openai` → `ai`. Tags without a colon are not collections, but a
+// bookmark tagged with a bare `name` still belongs to that collection
+// if one exists — see `tagBelongsToCollection`.
+const collectionFromTag = (tag: string): string | null => {
+  const colonIndex = tag.indexOf(':')
+  if (colonIndex <= 0) return null
+  return tag.slice(0, colonIndex)
+}
+
+export const tagBelongsToCollection = (tag: string, name: string): boolean =>
+  tag === name || tag.startsWith(`${name}:`)
+
+export const summariseCollections = (rows: TaggedRow[]): CollectionType[] => {
+  const collections = new Map<string, { count: number; tags: Set<string> }>()
+
+  for (const row of rows) {
+    for (const tag of row.tags ?? []) {
+      const name = collectionFromTag(tag)
+      if (!name) continue
+      const item = collections.get(name) ?? {
+        count: 0,
+        tags: new Set<string>(),
+      }
+      item.tags.add(tag)
+      collections.set(name, item)
+    }
+  }
+
+  for (const row of rows) {
+    const matched = new Set<string>()
+    for (const tag of row.tags ?? []) {
+      const name = collectionFromTag(tag) ?? tag
+      if (collections.has(name)) matched.add(name)
+    }
+    for (const name of matched) {
+      collections.get(name)!.count += 1
+    }
+  }
+
+  return Array.from(collections, ([collection, value]) => ({
+    bookmark_count: value.count,
+    collection,
+    tags: Array.from(value.tags).sort(),
+  })).sort(
+    (a, b) =>
+      (b.bookmark_count ?? 0) - (a.bookmark_count ?? 0) ||
+      a.collection.localeCompare(b.collection),
+  )
+}

--- a/packages/web/worker/mcp/tools.ts
+++ b/packages/web/worker/mcp/tools.ts
@@ -166,15 +166,23 @@ const getCollectionCounts = async (ctx: ToolContext) => {
     .select({ tags: bookmarks.tags })
     .from(bookmarks)
     .where(and(eq(bookmarks.user, ctx.userId), eq(bookmarks.status, 'active')))
-  const counts = new Map<string, number>()
-
+  const collections = new Set<string>()
   for (const row of rows) {
-    const seen = new Set<string>()
     for (const tag of row.tags ?? []) {
       const colonIndex = tag.indexOf(':')
       if (colonIndex <= 0) continue
       const name = tag.slice(0, colonIndex)
-      if (!name || seen.has(name)) continue
+      if (name) collections.add(name)
+    }
+  }
+
+  const counts = new Map<string, number>()
+  for (const row of rows) {
+    const seen = new Set<string>()
+    for (const tag of row.tags ?? []) {
+      const colonIndex = tag.indexOf(':')
+      const name = colonIndex > 0 ? tag.slice(0, colonIndex) : tag
+      if (!name || seen.has(name) || !collections.has(name)) continue
       seen.add(name)
       counts.set(name, (counts.get(name) ?? 0) + 1)
     }

--- a/packages/web/worker/mcp/tools.ts
+++ b/packages/web/worker/mcp/tools.ts
@@ -4,6 +4,7 @@ import type { BookmarkStatus, BookmarkType } from '@/types/db'
 import { matchTagsSource } from '@/utils/matchTags'
 import { bookmarks } from '../../db/schema'
 import { bookmarkToRow } from '../bookmarks/mapper'
+import { summariseCollections } from '../collections'
 import type { RequestContext } from '../context'
 import { linkType } from '../scraper/link-type'
 import Scraper from '../scraper/scraper'
@@ -166,31 +167,7 @@ const getCollectionCounts = async (ctx: ToolContext) => {
     .select({ tags: bookmarks.tags })
     .from(bookmarks)
     .where(and(eq(bookmarks.user, ctx.userId), eq(bookmarks.status, 'active')))
-  const collections = new Set<string>()
-  for (const row of rows) {
-    for (const tag of row.tags ?? []) {
-      const colonIndex = tag.indexOf(':')
-      if (colonIndex <= 0) continue
-      const name = tag.slice(0, colonIndex)
-      if (name) collections.add(name)
-    }
-  }
-
-  const counts = new Map<string, number>()
-  for (const row of rows) {
-    const seen = new Set<string>()
-    for (const tag of row.tags ?? []) {
-      const colonIndex = tag.indexOf(':')
-      const name = colonIndex > 0 ? tag.slice(0, colonIndex) : tag
-      if (!name || seen.has(name) || !collections.has(name)) continue
-      seen.add(name)
-      counts.set(name, (counts.get(name) ?? 0) + 1)
-    }
-  }
-
-  return Array.from(counts, ([name, count]) => ({ count, name })).sort(
-    (a, b) => b.count - a.count || a.name.localeCompare(b.name),
-  )
+  return summariseCollections(rows)
 }
 
 const getTypeCounts = async (ctx: ToolContext) => {
@@ -333,7 +310,7 @@ const getStats: McpTool = {
           getCollectionCounts(ctx),
         ])
       const collections = collectionRows.map(
-        (entry) => `  ${entry.name}: ${entry.count}`,
+        (entry) => `  ${entry.collection}: ${entry.bookmark_count}`,
       )
       const lines = [
         `Bookmarks: ${all.total} total, ${stars.total} starred, ${publicItems.total} public, ${trash.total} in trash, ${top.total} with clicks`,

--- a/packages/web/worker/mcp/tools.ts
+++ b/packages/web/worker/mcp/tools.ts
@@ -161,6 +161,30 @@ const getTagCounts = async (ctx: ToolContext) => {
   )
 }
 
+const getCollectionCounts = async (ctx: ToolContext) => {
+  const rows = await ctx.requestContext.db
+    .select({ tags: bookmarks.tags })
+    .from(bookmarks)
+    .where(and(eq(bookmarks.user, ctx.userId), eq(bookmarks.status, 'active')))
+  const counts = new Map<string, number>()
+
+  for (const row of rows) {
+    const seen = new Set<string>()
+    for (const tag of row.tags ?? []) {
+      const colonIndex = tag.indexOf(':')
+      if (colonIndex <= 0) continue
+      const name = tag.slice(0, colonIndex)
+      if (!name || seen.has(name)) continue
+      seen.add(name)
+      counts.set(name, (counts.get(name) ?? 0) + 1)
+    }
+  }
+
+  return Array.from(counts, ([name, count]) => ({ count, name })).sort(
+    (a, b) => b.count - a.count || a.name.localeCompare(b.name),
+  )
+}
+
 const getTypeCounts = async (ctx: ToolContext) => {
   const rows = await ctx.requestContext.db
     .select({ type: bookmarks.type })
@@ -285,7 +309,7 @@ const getStats: McpTool = {
   },
   handler: async (_args, ctx) => {
     try {
-      const [all, top, publicItems, stars, trash, types, tags] =
+      const [all, top, publicItems, stars, trash, types, tags, collectionRows] =
         await Promise.all([
           listBookmarkRows(ctx, { limit: 1, status: 'active' }),
           listBookmarkRows(ctx, { limit: 1, status: 'active', top: true }),
@@ -298,24 +322,11 @@ const getStats: McpTool = {
           listBookmarkRows(ctx, { limit: 1, status: 'inactive' }),
           getTypeCounts(ctx),
           getTagCounts(ctx),
+          getCollectionCounts(ctx),
         ])
-      const collectionCounts = new Map<string, number>()
-      for (const tag of tags) {
-        const colonIndex = tag.tag.indexOf(':')
-        if (colonIndex <= 0) continue
-        const name = tag.tag.slice(0, colonIndex)
-        if (!name) continue
-        collectionCounts.set(
-          name,
-          (collectionCounts.get(name) ?? 0) + (tag.count ?? 0),
-        )
-      }
-      const collections = Array.from(collectionCounts, ([name, count]) => ({
-        count,
-        name,
-      }))
-        .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
-        .map((entry) => `  ${entry.name}: ${entry.count}`)
+      const collections = collectionRows.map(
+        (entry) => `  ${entry.name}: ${entry.count}`,
+      )
       const lines = [
         `Bookmarks: ${all.total} total, ${stars.total} starred, ${publicItems.total} public, ${trash.total} in trash, ${top.total} with clicks`,
         '',

--- a/packages/web/worker/mcp/tools.ts
+++ b/packages/web/worker/mcp/tools.ts
@@ -299,9 +299,23 @@ const getStats: McpTool = {
           getTypeCounts(ctx),
           getTagCounts(ctx),
         ])
-      const collections = tags
-        .filter((tag) => tag.tag.startsWith('collection:'))
-        .map((tag) => `  ${tag.tag.replace('collection:', '')}: ${tag.count}`)
+      const collectionCounts = new Map<string, number>()
+      for (const tag of tags) {
+        const colonIndex = tag.tag.indexOf(':')
+        if (colonIndex <= 0) continue
+        const name = tag.tag.slice(0, colonIndex)
+        if (!name) continue
+        collectionCounts.set(
+          name,
+          (collectionCounts.get(name) ?? 0) + (tag.count ?? 0),
+        )
+      }
+      const collections = Array.from(collectionCounts, ([name, count]) => ({
+        count,
+        name,
+      }))
+        .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+        .map((entry) => `  ${entry.name}: ${entry.count}`)
       const lines = [
         `Bookmarks: ${all.total} total, ${stars.total} starred, ${publicItems.total} public, ${trash.total} in trash, ${top.total} with clicks`,
         '',

--- a/packages/web/worker/meta.ts
+++ b/packages/web/worker/meta.ts
@@ -359,11 +359,13 @@ export const getCollectionBookmarks = async (context: HonoContext) => {
     )
     const limit = params.limit ?? DEFAULT_API_RESPONSE_LIMIT
     const offset = params.offset ?? 0
-    const rows = (await getActiveBookmarks(auth)).filter((bookmark) =>
-      (bookmark.tags ?? []).some(
-        (tag) => tag === name || tag.startsWith(`${name}:`),
-      ),
-    )
+    const rows = (await getActiveBookmarks(auth))
+      .filter((bookmark) =>
+        (bookmark.tags ?? []).some(
+          (tag) => tag === name || tag.startsWith(`${name}:`),
+        ),
+      )
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
     const data = rows.slice(offset, offset + limit).map(bookmarkToRow)
 
     return new Response(

--- a/packages/web/worker/meta.ts
+++ b/packages/web/worker/meta.ts
@@ -102,12 +102,14 @@ const collectionCounts = (rows: BookmarkRow[]): CollectionType[] => {
   const collections = new Map<string, { count: number; tags: Set<string> }>()
 
   for (const row of rows) {
+    const seen = new Set<string>()
     for (const tag of row.tags ?? []) {
-      if (!tag.startsWith('collection:')) {
+      const colonIndex = tag.indexOf(':')
+      if (colonIndex <= 0) {
         continue
       }
 
-      const [, collection] = tag.split(':')
+      const collection = tag.slice(0, colonIndex)
       if (!collection) {
         continue
       }
@@ -116,8 +118,11 @@ const collectionCounts = (rows: BookmarkRow[]): CollectionType[] => {
         count: 0,
         tags: new Set<string>(),
       }
-      item.count += 1
       item.tags.add(tag)
+      if (!seen.has(collection)) {
+        item.count += 1
+        seen.add(collection)
+      }
       collections.set(collection, item)
     }
   }
@@ -125,8 +130,12 @@ const collectionCounts = (rows: BookmarkRow[]): CollectionType[] => {
   return Array.from(collections, ([collection, value]) => ({
     bookmark_count: value.count,
     collection,
-    tags: Array.from(value.tags),
-  }))
+    tags: Array.from(value.tags).sort(),
+  })).sort(
+    (a, b) =>
+      (b.bookmark_count ?? 0) - (a.bookmark_count ?? 0) ||
+      a.collection.localeCompare(b.collection),
+  )
 }
 
 export const getMeta = async (context: HonoContext) => {
@@ -352,8 +361,7 @@ export const getCollectionBookmarks = async (context: HonoContext) => {
     const offset = params.offset ?? 0
     const rows = (await getActiveBookmarks(auth)).filter((bookmark) =>
       (bookmark.tags ?? []).some(
-        (tag) =>
-          tag === `collection:${name}` || tag.startsWith(`collection:${name}:`),
+        (tag) => tag === name || tag.startsWith(`${name}:`),
       ),
     )
     const data = rows.slice(offset, offset + limit).map(bookmarkToRow)

--- a/packages/web/worker/meta.ts
+++ b/packages/web/worker/meta.ts
@@ -3,10 +3,11 @@ import type { Context } from 'hono'
 import { API_HEADERS, DEFAULT_API_RESPONSE_LIMIT } from '@/constants'
 import { apiParameters } from '@/utils/fetching/apiParameters'
 import { errorResponse } from '@/utils/fetching/errorResponse'
-import type { CollectionType, MetaTag, MetaType } from '@/utils/fetching/meta'
+import type { MetaTag, MetaType } from '@/utils/fetching/meta'
 import { getErrorMessage } from '@/utils/get-error-message'
 import { bookmarks, toots, tweets } from '../db/schema'
 import { bookmarkToRow } from './bookmarks/mapper'
+import { summariseCollections, tagBelongsToCollection } from './collections'
 import { requireRequestContext } from './context'
 import type { WorkerEnv } from './env'
 
@@ -98,58 +99,6 @@ const typeCounts = (rows: BookmarkRow[]): MetaType[] => {
   }))
 }
 
-const collectionCounts = (rows: BookmarkRow[]): CollectionType[] => {
-  const collections = new Map<string, { count: number; tags: Set<string> }>()
-
-  for (const row of rows) {
-    for (const tag of row.tags ?? []) {
-      const colonIndex = tag.indexOf(':')
-      if (colonIndex <= 0) {
-        continue
-      }
-
-      const collection = tag.slice(0, colonIndex)
-      if (!collection) {
-        continue
-      }
-
-      const item = collections.get(collection) ?? {
-        count: 0,
-        tags: new Set<string>(),
-      }
-      item.tags.add(tag)
-      collections.set(collection, item)
-    }
-  }
-
-  for (const row of rows) {
-    const seen = new Set<string>()
-    for (const tag of row.tags ?? []) {
-      const colonIndex = tag.indexOf(':')
-      const name = colonIndex > 0 ? tag.slice(0, colonIndex) : tag
-      if (!name || seen.has(name)) {
-        continue
-      }
-      const item = collections.get(name)
-      if (!item) {
-        continue
-      }
-      item.count += 1
-      seen.add(name)
-    }
-  }
-
-  return Array.from(collections, ([collection, value]) => ({
-    bookmark_count: value.count,
-    collection,
-    tags: Array.from(value.tags).sort(),
-  })).sort(
-    (a, b) =>
-      (b.bookmark_count ?? 0) - (a.bookmark_count ?? 0) ||
-      a.collection.localeCompare(b.collection),
-  )
-}
-
 export const getMeta = async (context: HonoContext) => {
   try {
     const auth = await getAuthed(context)
@@ -219,7 +168,7 @@ export const getMeta = async (context: HonoContext) => {
     return new Response(
       JSON.stringify({
         all,
-        collections: collectionCounts(rows),
+        collections: summariseCollections(rows),
         likedToots,
         likedTweets,
         public: publicItems,
@@ -342,7 +291,7 @@ export const getCollectionsTags = async (context: HonoContext) => {
     }
 
     return new Response(
-      JSON.stringify(collectionCounts(await getActiveBookmarks(auth))),
+      JSON.stringify(summariseCollections(await getActiveBookmarks(auth))),
       {
         headers: API_HEADERS,
         status: 200,
@@ -366,6 +315,13 @@ export const getCollectionBookmarks = async (context: HonoContext) => {
     }
 
     const name = context.req.param('collection')
+    if (!name) {
+      return errorResponse({
+        reason: 'Missing collection name',
+        status: 400,
+      })
+    }
+
     const params = apiParameters(
       Object.fromEntries(new URL(context.req.url).searchParams),
     )
@@ -373,9 +329,7 @@ export const getCollectionBookmarks = async (context: HonoContext) => {
     const offset = params.offset ?? 0
     const rows = (await getActiveBookmarks(auth))
       .filter((bookmark) =>
-        (bookmark.tags ?? []).some(
-          (tag) => tag === name || tag.startsWith(`${name}:`),
-        ),
+        (bookmark.tags ?? []).some((tag) => tagBelongsToCollection(tag, name)),
       )
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
     const data = rows.slice(offset, offset + limit).map(bookmarkToRow)

--- a/packages/web/worker/meta.ts
+++ b/packages/web/worker/meta.ts
@@ -102,7 +102,6 @@ const collectionCounts = (rows: BookmarkRow[]): CollectionType[] => {
   const collections = new Map<string, { count: number; tags: Set<string> }>()
 
   for (const row of rows) {
-    const seen = new Set<string>()
     for (const tag of row.tags ?? []) {
       const colonIndex = tag.indexOf(':')
       if (colonIndex <= 0) {
@@ -119,11 +118,24 @@ const collectionCounts = (rows: BookmarkRow[]): CollectionType[] => {
         tags: new Set<string>(),
       }
       item.tags.add(tag)
-      if (!seen.has(collection)) {
-        item.count += 1
-        seen.add(collection)
-      }
       collections.set(collection, item)
+    }
+  }
+
+  for (const row of rows) {
+    const seen = new Set<string>()
+    for (const tag of row.tags ?? []) {
+      const colonIndex = tag.indexOf(':')
+      const name = colonIndex > 0 ? tag.slice(0, colonIndex) : tag
+      if (!name || seen.has(name)) {
+        continue
+      }
+      const item = collections.get(name)
+      if (!item) {
+        continue
+      }
+      item.count += 1
+      seen.add(name)
     }
   }
 

--- a/packages/web/worker/shares.ts
+++ b/packages/web/worker/shares.ts
@@ -46,12 +46,12 @@ const shareBookmarksCondition = (
     return and(base, arrayContains(bookmarks.tags, [name]))
   }
 
-  // collection: tag is "collection:NAME" or "collection:NAME:..."
+  // collection: any tag equal to NAME or starting with "NAME:"
   return and(
     base,
     or(
-      arrayContains(bookmarks.tags, [`collection:${name}`]),
-      sql`EXISTS (SELECT 1 FROM unnest(${bookmarks.tags}) AS t WHERE t LIKE ${`collection:${name}:%`})`,
+      arrayContains(bookmarks.tags, [name]),
+      sql`EXISTS (SELECT 1 FROM unnest(${bookmarks.tags}) AS t WHERE t LIKE ${`${name}:%`})`,
     ),
   )
 }


### PR DESCRIPTION
## Summary
- `/api/meta` (and `/api/collections-tags`, `/api/collections/:collection`, MCP `get_stats`, share resolution) returned no collections because the auth/neon refactor (f612f7a) narrowed the matcher to the literal `collection:` prefix.
- Collections are actually any tag formatted as `<prefix>:<rest>` (e.g. `ai:openai` → collection `ai`), per the original supabase `collection_tags_view` / `get_bookmarks_by_collection` definitions.
- Restored prefix-based derivation, deduped bookmark counts per collection, and aligned share + collection-bookmark filters to `tag === name || tag.startsWith("name:")`.

## Test plan
- [ ] `GET /api/meta` returns populated `collections` for an account with `ai:openai`-style tags
- [ ] `GET /api/collections-tags` matches
- [ ] `GET /api/collections/:name` returns bookmarks tagged `name` or `name:*`
- [ ] Sidebar `CollectionList` renders entries
- [ ] MCP `get_stats` lists collections under "Collections:"
- [ ] Existing share by collection still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore collection detection from any tag prefix and include bare-name tags in counts so collections populate again in meta, shares, and MCP stats. Also sort collection bookmarks by newest first.

- **Bug Fixes**
  - Derive collections from any tag containing a colon; collection is the text before the first colon. A bookmark belongs if any tag equals the name or starts with "name:".
  - Deduplicate per-bookmark counts in `/api/meta` and MCP `get_stats`; sort collections by count, then name (meta also sorts tag lists).
  - Order collection bookmarks by `created_at` desc.

- **Refactors**
  - Extract shared helpers (`summariseCollections`, `tagBelongsToCollection`) to `worker/collections.ts` and use in meta and MCP; guard `GET /api/collections/:collection` when the name is missing.

<sup>Written for commit 12b760645249ea1a0780a94cad158ea5d3d4af3d. Summary will update on new commits. <a href="https://cubic.dev/pr/mrmartineau/Otter/pull/25?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

