### PR TITLE
feat(web): redesign signed-out homepage with editorial field-notes aesthetic

### DIFF
--- a/packages/web/src/components/Landing.css
+++ b/packages/web/src/components/Landing.css
@@ -1,0 +1,481 @@
+.landing {
+  --paper: var(--sand-1);
+  --ink: var(--sand-12);
+  --ink-soft: var(--sand-11);
+  --rule: color-mix(in srgb, var(--sand-12) 18%, transparent);
+  --pop: var(--accent9);
+  --pop-bright: var(--accent11);
+  --pop-soft: var(--accent5);
+
+  position: relative;
+  min-height: 100vh;
+  background-color: var(--paper);
+  color: var(--ink);
+
+  /* paper grain */
+  &::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    pointer-events: none;
+    opacity: 0.04;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+}
+
+.landing-container {
+  max-width: 1100px;
+  margin-inline: auto;
+  padding-inline: var(--space-s);
+}
+
+.landing-mono {
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ---------- top bar ---------- */
+
+.landing-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-s);
+  padding-block: var(--space-s);
+  border-bottom: 2px solid var(--ink);
+}
+
+.landing-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  color: var(--ink);
+  font-size: var(--step-1);
+  font-variation-settings:
+    "wght" 700,
+    "wdth" 110;
+
+  &:hover {
+    color: var(--pop-bright);
+  }
+}
+
+.landing-top-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-m);
+
+  a {
+    color: var(--ink);
+    border-bottom: 2px solid transparent;
+    padding-block: 0.2em;
+
+    &:hover {
+      color: var(--pop-bright);
+      border-bottom-color: var(--pop);
+    }
+  }
+}
+
+/* ---------- buttons ---------- */
+
+.landing-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6em;
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.9em 1.3em;
+  border: 2px solid var(--ink);
+  background-color: var(--paper);
+  color: var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+  transition:
+    translate 0.15s var(--ease-in-out-4),
+    box-shadow 0.15s var(--ease-in-out-4);
+
+  &:hover {
+    color: var(--ink);
+    translate: -2px -2px;
+    box-shadow: 6px 6px 0 var(--pop);
+  }
+
+  &:active {
+    translate: 2px 2px;
+    box-shadow: 0 0 0 var(--ink);
+  }
+}
+
+.landing-btn-primary {
+  background-color: var(--ink);
+  color: var(--paper);
+
+  &:hover {
+    color: var(--paper);
+  }
+}
+
+/* ---------- hero ---------- */
+
+.landing-hero {
+  position: relative;
+  padding-block: clamp(3rem, 8vw, 6.5rem) clamp(3rem, 7vw, 5.5rem);
+}
+
+.landing-kicker {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.75em;
+  color: var(--pop-bright);
+
+  &::before {
+    content: "\2733"; /* ✳ */
+    color: var(--pop);
+  }
+}
+
+.landing-display {
+  margin-top: var(--space-m);
+  max-width: 13ch;
+  font-size: clamp(3rem, 1.5rem + 8vw, 6.75rem);
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+  font-variation-settings:
+    "wght" 800,
+    "wdth" 112;
+
+  em {
+    display: inline-block;
+    rotate: -1.5deg;
+    font-style: normal;
+    padding-inline: 0.1em;
+    background-color: var(--pop-soft);
+    box-decoration-break: clone;
+  }
+}
+
+.landing-lede {
+  margin-top: var(--space-m);
+  max-width: 52ch;
+  font-size: var(--step-1);
+  line-height: var(--line-height-snug);
+  color: var(--ink-soft);
+  text-wrap: pretty;
+}
+
+.landing-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-s);
+  margin-top: var(--space-l);
+}
+
+.landing-aside {
+  margin-top: var(--space-l);
+  max-width: 38ch;
+  font-family: var(--font-mono);
+  font-size: var(--step--2);
+  line-height: var(--line-height-normal);
+  color: var(--ink-soft);
+}
+
+.landing-stamp {
+  display: none;
+  position: absolute;
+  top: clamp(3rem, 7vw, 5.5rem);
+  right: 0;
+  width: clamp(160px, 18vw, 220px);
+  aspect-ratio: 1;
+
+  @media (min-width: 800px) {
+    display: block;
+  }
+
+  svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    animation: landing-spin 40s linear infinite;
+
+    text {
+      fill: var(--pop);
+      font-family: var(--font-mono);
+      font-size: 14.5px;
+      letter-spacing: 0.35em;
+      text-transform: uppercase;
+    }
+  }
+
+  img {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 45%;
+    height: auto;
+    rotate: -6deg;
+  }
+}
+
+@keyframes landing-spin {
+  to {
+    rotate: 360deg;
+  }
+}
+
+/* ---------- ticker ---------- */
+
+.landing-ticker {
+  overflow: hidden;
+  border-block: 2px solid var(--ink);
+  background-color: var(--pop-soft);
+  padding-block: 0.65em;
+}
+
+.landing-ticker-track {
+  display: flex;
+  width: max-content;
+  animation: landing-marquee 45s linear infinite;
+
+  span {
+    display: flex;
+    gap: 1.5em;
+    padding-inline-end: 1.5em;
+    white-space: nowrap;
+    color: var(--ink);
+  }
+}
+
+@keyframes landing-marquee {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* ---------- section headers ---------- */
+
+.landing-section-header {
+  padding-block: clamp(3rem, 7vw, 5rem) var(--space-l);
+}
+
+.landing-section-title {
+  margin-top: var(--space-xs);
+  font-size: clamp(1.75rem, 1rem + 3vw, 3rem);
+  letter-spacing: -0.01em;
+  font-variation-settings:
+    "wght" 750,
+    "wdth" 110;
+}
+
+/* ---------- field guide ---------- */
+
+.landing-chapter {
+  display: grid;
+  gap: var(--space-m);
+  border-top: 2px solid var(--ink);
+  padding-block: var(--space-l) var(--space-xl);
+
+  @media (min-width: 900px) {
+    grid-template-columns: 240px 1fr;
+    gap: var(--space-xl);
+  }
+}
+
+.landing-chapter-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5em;
+
+  @media (min-width: 900px) {
+    flex-direction: column;
+    position: sticky;
+    top: var(--space-m);
+    align-self: start;
+  }
+}
+
+.landing-chapter-numeral {
+  font-family: var(--font-mono);
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  line-height: 1;
+  color: var(--pop);
+}
+
+.landing-chapter-title {
+  font-size: var(--step-2);
+  font-variation-settings:
+    "wght" 700,
+    "wdth" 110;
+}
+
+.landing-entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.landing-entry {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr;
+  column-gap: var(--space-s);
+  padding-block: var(--space-m);
+  padding-inline: var(--space-2xs);
+  border-top: 1px solid var(--rule);
+  transition: background-color 0.15s var(--ease-in-out-4);
+
+  &:first-child {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  &:hover {
+    background-color: color-mix(in srgb, var(--pop-soft) 40%, transparent);
+  }
+
+  h4 {
+    font-size: var(--step-1);
+    font-variation-settings:
+      "wght" 650,
+      "wdth" 108;
+  }
+
+  p {
+    grid-column: 2;
+    margin-top: var(--space-3xs);
+    max-width: 55ch;
+    color: var(--ink-soft);
+    text-wrap: pretty;
+  }
+}
+
+.landing-entry-num {
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  color: var(--pop-bright);
+  padding-top: 0.4em;
+}
+
+/* ---------- clippings (recent public bookmarks) ---------- */
+
+.landing-clippings {
+  border-top: 2px solid var(--ink);
+  padding-bottom: clamp(3rem, 7vw, 5rem);
+}
+
+.landing-clippings-grid {
+  display: grid;
+  gap: var(--space-l);
+  max-width: 760px;
+}
+
+.landing-clipping {
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: -11px;
+    left: 50%;
+    z-index: 1;
+    width: 96px;
+    height: 24px;
+    translate: -50%;
+    rotate: -2deg;
+    background-color: color-mix(in srgb, var(--pop) 30%, transparent);
+  }
+
+  &:nth-child(odd) {
+    rotate: -0.6deg;
+  }
+
+  &:nth-child(even) {
+    rotate: 0.5deg;
+
+    &::before {
+      rotate: 2deg;
+      left: 40%;
+    }
+  }
+
+  &:hover {
+    rotate: 0deg;
+  }
+}
+
+.landing-clippings-more {
+  margin-top: var(--space-l);
+}
+
+/* ---------- closing ---------- */
+
+.landing-final {
+  border-top: 2px solid var(--ink);
+  padding-block: clamp(4rem, 10vw, 7rem);
+  text-align: center;
+}
+
+.landing-final-title {
+  font-size: clamp(2.5rem, 1rem + 7vw, 5.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+  font-variation-settings:
+    "wght" 800,
+    "wdth" 112;
+}
+
+.landing-final p {
+  margin-top: var(--space-m);
+  margin-inline: auto;
+  max-width: 45ch;
+  color: var(--ink-soft);
+  font-size: var(--step-0);
+}
+
+.landing-final .landing-btn {
+  margin-top: var(--space-l);
+}
+
+/* ---------- footer ---------- */
+
+.landing-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-s);
+  border-top: 2px solid var(--ink);
+  padding-block: var(--space-m) var(--space-l);
+  font-family: var(--font-mono);
+  font-size: var(--step--2);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+
+  a {
+    color: var(--ink);
+    border-bottom: 1px solid var(--rule);
+
+    &:hover {
+      color: var(--pop-bright);
+      border-bottom-color: var(--pop);
+    }
+  }
+}
+
+.landing-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-m);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-ticker-track,
+  .landing-stamp svg {
+    animation: none;
+  }
+}

--- a/packages/web/src/routes/_public/index.tsx
+++ b/packages/web/src/routes/_public/index.tsx
@@ -1,23 +1,6 @@
-import {
-  ArrowRightIcon,
-  BookmarkSimpleIcon,
-  BrainIcon,
-  BrowserIcon,
-  DeviceMobileIcon,
-  FilmStripIcon,
-  GlobeIcon,
-  LockIcon,
-  MagnifyingGlassIcon,
-  MoonStarsIcon,
-  PlugIcon,
-  RssIcon,
-  TagIcon,
-  UserCircleIcon,
-} from '@phosphor-icons/react'
+import { ArrowRightIcon, ArrowUpRightIcon } from '@phosphor-icons/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
-import { Button } from '@/components/Button'
-import { Flex } from '@/components/Flex'
 import { Link } from '@/components/Link'
 import { PublicBookmarkItem } from '@/components/PublicBookmarkItem'
 import type { Bookmark } from '@/types/db'
@@ -31,6 +14,7 @@ import {
 } from '../../constants'
 
 const RECENT_PREVIEW_LIMIT = 5
+const GITHUB_URL = 'https://github.com/mrmartineau/Otter'
 
 export const Route = createFileRoute('/_public/')({
   component: Index,
@@ -44,71 +28,111 @@ export const Route = createFileRoute('/_public/')({
   },
 })
 
-const features = [
+const chapters = [
   {
-    description: 'Save links, articles, videos, and more with rich metadata.',
-    icon: BookmarkSimpleIcon,
-    title: 'Bookmarking',
+    features: [
+      {
+        description:
+          'Save links, articles, videos and podcasts. Titles, descriptions and images are scraped for you.',
+        title: 'Bookmarking',
+      },
+      {
+        description:
+          'Parse RSS feeds and pull rich metadata out of any URL you throw at it.',
+        title: 'RSS & scraping',
+      },
+      {
+        description:
+          'Back up your own toots and the ones you favourited, straight from Mastodon.',
+        title: 'Mastodon backup',
+      },
+      {
+        description:
+          'A kanban board for movies, TV shows and games — from “one day” to “done”.',
+        title: 'Media tracking',
+      },
+    ],
+    numeral: 'I',
+    title: 'Collect',
   },
   {
-    description: 'Organise with tags, collections, stars, and filters.',
-    icon: TagIcon,
-    title: 'Tags & Collections',
+    features: [
+      {
+        description:
+          'Tags, collections, stars and filters. File things the way your brain works.',
+        title: 'Tags & collections',
+      },
+      {
+        description:
+          'Full-text search across everything you have ever saved. Nothing sinks to the bottom.',
+        title: 'Search that finds it',
+      },
+      {
+        description:
+          'Let Cloudflare Workers AI rewrite scruffy titles and descriptions for you.',
+        title: 'AI assist',
+      },
+      {
+        description:
+          'Dark and light mode that quietly follows your system preference.',
+        title: 'Easy on the eyes',
+      },
+    ],
+    numeral: 'II',
+    title: 'Organise',
   },
   {
-    description: 'Full-text search across all your saved items.',
-    icon: MagnifyingGlassIcon,
-    title: 'Search',
-  },
-  {
-    description: 'Kanban board for tracking movies, TV shows, games, and more.',
-    icon: FilmStripIcon,
-    title: 'Media Tracking',
-  },
-  {
-    description: 'Rewrite titles and descriptions with Cloudflare Workers AI.',
-    icon: BrainIcon,
-    title: 'AI-Powered',
-  },
-  {
-    description: 'Parse RSS feeds and scrape metadata from any URL.',
-    icon: RssIcon,
-    title: 'RSS & Scraping',
-  },
-  {
-    description: 'Back up your own toots and favourite toots.',
-    icon: GlobeIcon,
-    title: 'Mastodon Integration',
-  },
-  {
-    description:
-      'Native iOS and macOS app with share extension for quickly saving bookmarks.',
-    icon: DeviceMobileIcon,
-    title: 'Native iOS App',
-  },
-  {
-    description:
-      'Browser extensions for Chrome and Firefox, Raycast extension, and bookmarklet.',
-    icon: BrowserIcon,
-    title: 'Extensions',
-  },
-  {
-    description: 'Automatic colour mode that follows your system preference.',
-    icon: MoonStarsIcon,
-    title: 'Dark & Light Mode',
-  },
-  {
-    description: 'Integrate with AI assistants via the Model Context Protocol.',
-    icon: PlugIcon,
-    title: 'MCP Server',
-  },
-  {
-    description:
-      'Your data stays yours. Run Otter on Cloudflare Workers with Neon Postgres.',
-    icon: LockIcon,
-    title: 'Private & Self-Hosted',
+    features: [
+      {
+        description:
+          'Native iOS and macOS app with a share extension — save from anywhere on your phone.',
+        title: 'In your pocket',
+      },
+      {
+        description:
+          'Chrome and Firefox extensions, a Raycast extension and a trusty bookmarklet.',
+        title: 'In your browser',
+      },
+      {
+        description:
+          'A built-in MCP server, so your AI assistant can rummage through your bookmarks too.',
+        title: 'In your AI tools',
+      },
+      {
+        description:
+          'Self-hosted on Cloudflare Workers with your own Postgres. Your data stays yours.',
+        title: 'On your terms',
+      },
+    ],
+    numeral: 'III',
+    title: 'Everywhere',
   },
 ]
+
+let featureCount = 0
+const numberedChapters = chapters.map((chapter) => ({
+  ...chapter,
+  features: chapter.features.map((feature) => ({
+    ...feature,
+    number: String(++featureCount).padStart(2, '0'),
+  })),
+}))
+
+const tickerItems = [
+  'Bookmarks',
+  'Full-text search',
+  'Tags',
+  'Collections',
+  'Media tracking',
+  'RSS',
+  'Mastodon',
+  'AI assist',
+  'MCP server',
+  'iOS app',
+  'Extensions',
+  'Self-hosted',
+]
+const tickerLine = tickerItems.map((item) => `${item} ✱`).join(' ')
 
 function Index() {
   const navigate = useNavigate()
@@ -123,107 +147,166 @@ function Index() {
   )
 
   return (
-    <div className="min-h-screen">
-      {/* Hero */}
-      <section className="py-3xl text-center px-s">
-        <img
-          src="/otter-logo.svg"
-          width="90"
-          height="90"
-          className="mx-auto"
-          alt="Otter logo"
-        />
-        <h1 className="mt-m">{CONTENT.appName}</h1>
-        <p className="mt-s text-step-1 text-[var(--text)] max-w-[50ch] mx-auto text-balance">
-          A self-hosted bookmark manager and media tracker built for people who
-          value privacy and ownership.
+    <div className="landing">
+      <header className="landing-top landing-container">
+        <a href="/" className="landing-wordmark">
+          <img src="/otter-logo.svg" width="32" height="32" alt="" />
+          {CONTENT.appName}
+        </a>
+        <nav className="landing-top-nav landing-mono">
+          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+            GitHub
+          </a>
+          <a href={ROUTE_SIGNIN}>{CONTENT.signInTitle}</a>
+        </nav>
+      </header>
+
+      <section className="landing-hero landing-container">
+        <p className="landing-kicker landing-mono">
+          Field notes · a self-hosted bookmark manager &amp; media tracker
         </p>
-        <Flex
-          align="center"
-          justify="center"
-          gap="s"
-          className="mt-m"
-          wrap="wrap"
-        >
-          <Button asChild>
-            <a href={ROUTE_SIGNIN}>
-              <UserCircleIcon weight="duotone" width="20" height="20" />
-              {CONTENT.signInTitle}
-            </a>
-          </Button>
-          <Button asChild variant="outline">
-            <a
-              href="https://github.com/mrmartineau/Otter"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View on GitHub
-            </a>
-          </Button>
-        </Flex>
-      </section>
-
-      {/* Recent public bookmarks */}
-      {recentBookmarks.data?.length ? (
-        <section className="max-w-[1000px] mx-auto px-s pb-3xl">
-          <h2 className="text-step-1 mb-m">Recent public bookmarks</h2>
-          <div className="grid gap-m">
-            {recentBookmarks.data.map((item: Bookmark) => (
-              <PublicBookmarkItem {...item} key={item.id} />
-            ))}
-          </div>
-          <Flex justify="center" className="mt-m">
-            <Button asChild variant="outline">
-              <a href={ROUTE_RECENT}>
-                View all
-                <ArrowRightIcon weight="bold" width="16" height="16" />
-              </a>
-            </Button>
-          </Flex>
-        </section>
-      ) : null}
-
-      {/* Features */}
-      <section className="max-w-[1000px] mx-auto px-s pb-3xl">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-m">
-          {features.map((feature) => (
-            <div
-              key={feature.title}
-              className="rounded-lg border border-[var(--border)] bg-[var(--theme2)] p-m"
-            >
-              <feature.icon
-                weight="duotone"
-                width="28"
-                height="28"
-                className="text-[var(--accent9)] mb-xs"
+        <h1 className="landing-display">
+          Hold on to <em>the good stuff</em>.
+        </h1>
+        <p className="landing-lede">
+          Otter is where your links, articles, videos and half-watched TV shows
+          live. Save it, tag it, find it again — on your own infrastructure,
+          with nobody reading over your shoulder.
+        </p>
+        <div className="landing-cta-row">
+          <a href={ROUTE_SIGNIN} className="landing-btn landing-btn-primary">
+            Start your collection
+            <ArrowRightIcon weight="bold" width="16" height="16" />
+          </a>
+          <a
+            href={GITHUB_URL}
+            className="landing-btn"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Read the source
+            <ArrowUpRightIcon weight="bold" width="16" height="16" />
+          </a>
+        </div>
+        <p className="landing-aside">
+          * Sea otters keep a favourite rock in a pouch under their arm. This is
+          that, for the internet.
+        </p>
+        <div className="landing-stamp" aria-hidden="true">
+          <svg viewBox="0 0 200 200" aria-hidden="true">
+            <defs>
+              <path
+                id="landing-stamp-circle"
+                d="M100,100 m-82,0 a82,82 0 1,1 164,0 a82,82 0 1,1 -164,0"
               />
-              <h3 className="text-step-0 mb-3xs">{feature.title}</h3>
-              <p className="text-step--1 text-[var(--text)]">
-                {feature.description}
-              </p>
-            </div>
-          ))}
+            </defs>
+            <text>
+              <textPath href="#landing-stamp-circle">
+                Save it · tag it · find it again ·
+              </textPath>
+            </text>
+          </svg>
+          <img src="/otter-logo.svg" alt="" />
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="text-center pb-l px-s text-step--1">
-        <Flex align="center" justify="center" gap="s" wrap="wrap">
-          <span>
-            Made by{' '}
-            <a href="https://zander.wtf" className="underline">
-              Zander Martineau
-            </a>
-          </span>
-          <span>·</span>
-          <Link href="/privacy" className="underline">
-            Privacy Policy
-          </Link>
-          <span>·</span>
-          <Link href="/terms" className="underline">
-            Terms of Service
-          </Link>
-        </Flex>
+      <div className="landing-ticker" aria-hidden="true">
+        <div className="landing-ticker-track landing-mono">
+          <span>{tickerLine}</span>
+          <span>{tickerLine}</span>
+        </div>
+      </div>
+
+      <section className="landing-container">
+        <header className="landing-section-header">
+          <p className="landing-kicker landing-mono">The field guide</p>
+          <h2 className="landing-section-title">
+            Everything a hoarder needs, nothing a landlord wants
+          </h2>
+        </header>
+        {numberedChapters.map((chapter) => (
+          <div className="landing-chapter" key={chapter.numeral}>
+            <div className="landing-chapter-heading">
+              <span className="landing-chapter-numeral" aria-hidden="true">
+                {chapter.numeral}.
+              </span>
+              <h3 className="landing-chapter-title">{chapter.title}</h3>
+            </div>
+            <ol className="landing-entries">
+              {chapter.features.map((feature) => (
+                <li className="landing-entry" key={feature.title}>
+                  <span className="landing-entry-num" aria-hidden="true">
+                    {feature.number}
+                  </span>
+                  <h4>{feature.title}</h4>
+                  <p>{feature.description}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        ))}
+      </section>
+
+      {recentBookmarks.data?.length ? (
+        <section className="landing-clippings">
+          <div className="landing-container">
+            <header className="landing-section-header">
+              <p className="landing-kicker landing-mono">Fresh catch</p>
+              <h2 className="landing-section-title">Recently washed ashore</h2>
+            </header>
+            <div className="landing-clippings-grid">
+              {recentBookmarks.data.map((item: Bookmark) => (
+                <div className="landing-clipping" key={item.id}>
+                  <PublicBookmarkItem {...item} />
+                </div>
+              ))}
+            </div>
+            <div className="landing-clippings-more">
+              <a href={ROUTE_RECENT} className="landing-btn">
+                All public bookmarks
+                <ArrowRightIcon weight="bold" width="16" height="16" />
+              </a>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="landing-final">
+        <div className="landing-container">
+          <h2 className="landing-final-title">
+            Your shelf.
+            <br />
+            Your rules.
+          </h2>
+          <p>
+            Run it yourself on Cloudflare Workers and Postgres, or just sign in
+            and start saving. Either way, no algorithm gets a vote.
+          </p>
+          <a href={ROUTE_SIGNIN} className="landing-btn landing-btn-primary">
+            {CONTENT.signInTitle}
+            <ArrowRightIcon weight="bold" width="16" height="16" />
+          </a>
+        </div>
+      </section>
+
+      <footer className="landing-footer landing-container">
+        <span>
+          Made by{' '}
+          <a
+            href="https://zander.wtf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Zander Martineau
+          </a>
+        </span>
+        <div className="landing-footer-links">
+          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+            GitHub
+          </a>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/terms">Terms</Link>
+        </div>
       </footer>
     </div>
   )

--- a/packages/web/src/styles/components.css
+++ b/packages/web/src/styles/components.css
@@ -13,6 +13,7 @@
 @import "../components/IconButton.css";
 @import "../components/IconControl.css";
 @import "../components/Input.css";
+@import "../components/Landing.css";
 @import "../components/Link.css";
 @import "../components/Markdown.css";
 @import "../components/MediaCard.css";


### PR DESCRIPTION
## Summary

Replaces the signed-out homepage (centered logo hero + 3-column icon card grid) with an entirely new editorial **"field notes / collector's archive"** aesthetic, leaning into the otter theme (sea otters keep a favourite rock in a pouch — this is that, for the internet).

### What's new

- **Hero**: oversized display type (`Mona Sans` pushed to wght 800 / wdth 112) with a tilted violet marker-highlight on "the good stuff", a mono kicker, a rock-fact footnote aside, and a slowly rotating circular stamp ("save it · tag it · find it again") around the otter logo
- **Marquee ticker** of feature keywords between hero and content
- **Field guide**: the 12 features reorganised into three numbered chapters (I. Collect / II. Organise / III. Everywhere) presented as a ruled index ledger with mono entry numbers and sticky chapter headings — no icon cards
- **Recent public bookmarks** restyled as tilted "clippings" with tape marks
- **Closing CTA** ("Your shelf. Your rules.") and a mono footer
- Subtle paper-grain texture overlay; sharp 2px borders and offset hard shadows on buttons

### Implementation notes

- Built entirely on existing design tokens (`--sand-*` for the paper/ink palette, `--accent*` violet for pops), so **dark mode works automatically** — verified in both schemes
- All animations (marquee, stamp spin) respect `prefers-reduced-motion`
- Route logic (session redirect, recent-bookmarks loader) unchanged
- New `Landing.css` follows the existing colocated-component-CSS convention, imported via `styles/components.css`

### Verification

- `tsc -b` passes, `biome check` clean on changed files, `pnpm build` succeeds
- Rendered the built SPA with Playwright (mocked `/api/recent`) and screenshotted full pages in light and dark mode — shared in the session

https://claude.ai/code/session_01Tn96YR63Qe5i1DvjR7BuoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tn96YR63Qe5i1DvjR7BuoS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the signed-out homepage with an editorial field-notes aesthetic. Replaces the centered hero and icon grid with a clearer, more expressive layout.

- **New Features**
  - Hero with oversized display type, tilted highlight, mono kicker, and rotating circular stamp.
  - Marquee ticker of feature keywords between hero and content.
  - Field guide: three numbered chapters (Collect, Organise, Everywhere) rendered as a ruled index ledger with numbered entries.
  - Recent public bookmarks restyled as tilted clippings, plus an “All public bookmarks” button.
  - Closing CTA and mono footer, with paper-grain texture and crisp 2px borders with offset shadows.

- **Refactors**
  - Added `Landing.css` and imported it in `styles/components.css`.
  - Rebuilt `/_public/index.tsx` markup and copy; session redirect and recent-bookmarks loader unchanged.
  - Animations respect `prefers-reduced-motion`.
  - Uses existing design tokens (`--sand-*`, `--accent*`) so dark mode works automatically.

<sup>Written for commit 5469674dc9fa71e4f6ce04685a5b9ba6b2aaccdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/Otter/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

