### PR TITLE
feat(web): use Postgres full-text search and proper indexes for bookmark search

### DIFF
--- a/packages/web/db/schema.ts
+++ b/packages/web/db/schema.ts
@@ -1,8 +1,9 @@
-import { sql } from 'drizzle-orm'
+import { type SQL, sql } from 'drizzle-orm'
 import {
   bigint,
   boolean,
   check,
+  customType,
   index,
   json,
   numeric,
@@ -15,6 +16,12 @@ import {
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core'
+
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return 'tsvector'
+  },
+})
 
 export const feedsTypeEnum = pgEnum('feeds_type', ['rss', 'api'])
 
@@ -326,6 +333,11 @@ export const bookmarks = pgTable(
       .default(sql`timezone('utc', now())`),
     note: text('note'),
     public: boolean('public').notNull().default(false),
+    // Weighted full-text document over title (A), description (B) and note (C)
+    searchText: tsvector('search_text').generatedAlwaysAs(
+      (): SQL =>
+        sql`setweight(to_tsvector('english', coalesce(${bookmarks.title}, '')), 'A') || setweight(to_tsvector('english', coalesce(${bookmarks.description}, '')), 'B') || setweight(to_tsvector('english', coalesce(${bookmarks.note}, '')), 'C')`,
+    ),
     star: boolean('star').notNull().default(false),
     status: bookmarkStatusEnum('status').notNull().default('active'),
     tags: text('tags').array(),
@@ -336,8 +348,14 @@ export const bookmarks = pgTable(
     user: uuid('user').references(() => authUsers.id),
   },
   (table) => [
-    index('bookmarks_user_idx').on(table.user),
-    index('bookmarks_status_idx').on(table.status),
+    index('bookmarks_user_created_at_idx').on(
+      table.user,
+      table.createdAt.desc(),
+    ),
+    index('bookmarks_user_status_idx').on(table.user, table.status),
+    index('bookmarks_search_text_idx').using('gin', table.searchText),
+    index('bookmarks_tags_idx').using('gin', table.tags),
+    index('bookmarks_url_trgm_idx').using('gin', table.url.op('gin_trgm_ops')),
   ],
 )
 

--- a/packages/web/db/schema.ts
+++ b/packages/web/db/schema.ts
@@ -353,6 +353,14 @@ export const bookmarks = pgTable(
       table.createdAt.desc(),
     ),
     index('bookmarks_user_status_idx').on(table.user, table.status),
+    // Serves the cross-user public feed (getRecentPublicBookmarks):
+    // WHERE public AND status='active' ORDER BY created_at DESC. `public`
+    // leads because it is the selective predicate (status is near-constant).
+    index('bookmarks_public_status_created_at_idx').on(
+      table.public,
+      table.status,
+      table.createdAt.desc(),
+    ),
     index('bookmarks_search_text_idx').using('gin', table.searchText),
     index('bookmarks_tags_idx').using('gin', table.tags),
     index('bookmarks_url_trgm_idx').using('gin', table.url.op('gin_trgm_ops')),

--- a/packages/web/drizzle/0002_search.sql
+++ b/packages/web/drizzle/0002_search.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+DROP INDEX "bookmarks_status_idx";--> statement-breakpoint
+DROP INDEX "bookmarks_user_idx";--> statement-breakpoint
+ALTER TABLE "bookmarks" ADD COLUMN "search_text" "tsvector" GENERATED ALWAYS AS (setweight(to_tsvector('english', coalesce("bookmarks"."title", '')), 'A') || setweight(to_tsvector('english', coalesce("bookmarks"."description", '')), 'B') || setweight(to_tsvector('english', coalesce("bookmarks"."note", '')), 'C')) STORED;--> statement-breakpoint
+CREATE INDEX "bookmarks_user_created_at_idx" ON "bookmarks" USING btree ("user","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "bookmarks_user_status_idx" ON "bookmarks" USING btree ("user","status");--> statement-breakpoint
+CREATE INDEX "bookmarks_search_text_idx" ON "bookmarks" USING gin ("search_text");--> statement-breakpoint
+CREATE INDEX "bookmarks_tags_idx" ON "bookmarks" USING gin ("tags");--> statement-breakpoint
+CREATE INDEX "bookmarks_url_trgm_idx" ON "bookmarks" USING gin ("url" gin_trgm_ops);

--- a/packages/web/drizzle/0003_dear_stryfe.sql
+++ b/packages/web/drizzle/0003_dear_stryfe.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "bookmarks_public_status_created_at_idx" ON "bookmarks" USING btree ("public","status","created_at" DESC NULLS LAST);

--- a/packages/web/drizzle/meta/0002_snapshot.json
+++ b/packages/web/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2276 @@
+{
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "dialect": "postgresql",
+  "enums": {
+    "public.feeds_type": {
+      "name": "feeds_type",
+      "schema": "public",
+      "values": ["rss", "api"]
+    },
+    "public.media_rating": {
+      "name": "media_rating",
+      "schema": "public",
+      "values": [
+        "0",
+        "0.5",
+        "1",
+        "1.5",
+        "2",
+        "2.5",
+        "3",
+        "3.5",
+        "4",
+        "4.5",
+        "5"
+      ]
+    },
+    "public.media_status": {
+      "name": "media_status",
+      "schema": "public",
+      "values": ["now", "skipped", "done", "wishlist"]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": ["tv", "film", "game", "book", "podcast", "music", "other"]
+    },
+    "public.share_kind": {
+      "name": "share_kind",
+      "schema": "public",
+      "values": ["tag", "collection"]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": ["active", "inactive"]
+    },
+    "public.type": {
+      "name": "type",
+      "schema": "public",
+      "values": [
+        "link",
+        "video",
+        "audio",
+        "recipe",
+        "image",
+        "document",
+        "article",
+        "game",
+        "book",
+        "event",
+        "product",
+        "note",
+        "file",
+        "place"
+      ]
+    }
+  },
+  "id": "a7af9296-a811-4810-81cd-0f24a3ebaa63",
+  "policies": {},
+  "prevId": "fae7df6d-6cf0-43c2-9869-6f3ce49b72be",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.account": {
+      "checkConstraints": {},
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "account_id": {
+          "name": "account_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "id_token": {
+          "name": "id_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "password": {
+          "name": "password",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "scope": {
+          "name": "scope",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "account_user_id_user_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "account",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "account_user_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "account",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.bookmark_tags": {
+      "checkConstraints": {},
+      "columns": {
+        "bookmark_id": {
+          "name": "bookmark_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmark_tags_pkey": {
+          "columns": ["bookmark_id", "tag_id"],
+          "name": "bookmark_tags_pkey"
+        }
+      },
+      "foreignKeys": {
+        "bookmark_tags_bookmark_id_bookmarks_id_fk": {
+          "columnsFrom": ["bookmark_id"],
+          "columnsTo": ["id"],
+          "name": "bookmark_tags_bookmark_id_bookmarks_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "bookmark_tags",
+          "tableTo": "bookmarks"
+        },
+        "bookmark_tags_tag_id_tags_id_fk": {
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "name": "bookmark_tags_tag_id_tags_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "bookmark_tags",
+          "tableTo": "tags"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "bookmark_tags",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.bookmarks": {
+      "checkConstraints": {},
+      "columns": {
+        "bluesky_post_uri": {
+          "name": "bluesky_post_uri",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "click_count": {
+          "default": 0,
+          "name": "click_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "smallint"
+        },
+        "created_at": {
+          "default": "timezone('utc', now())",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "description": {
+          "name": "description",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "feed": {
+          "name": "feed",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "image": {
+          "name": "image",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "modified_at": {
+          "default": "timezone('utc', now())",
+          "name": "modified_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "note": {
+          "name": "note",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "public": {
+          "default": false,
+          "name": "public",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "search_text": {
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"bookmarks\".\"title\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"bookmarks\".\"description\", '')), 'B') || setweight(to_tsvector('english', coalesce(\"bookmarks\".\"note\", '')), 'C')",
+            "type": "stored"
+          },
+          "name": "search_text",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "tsvector"
+        },
+        "star": {
+          "default": false,
+          "name": "star",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "status": {
+          "default": "'active'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "status",
+          "typeSchema": "public"
+        },
+        "tags": {
+          "name": "tags",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "title": {
+          "name": "title",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "tweet": {
+          "name": "tweet",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "type": {
+          "default": "'link'",
+          "name": "type",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "type",
+          "typeSchema": "public"
+        },
+        "url": {
+          "name": "url",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user": {
+          "name": "user",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "bookmarks_user_user_id_fk": {
+          "columnsFrom": ["user"],
+          "columnsTo": ["id"],
+          "name": "bookmarks_user_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "bookmarks",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "bookmarks_search_text_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "search_text",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "gin",
+          "name": "bookmarks_search_text_idx",
+          "with": {}
+        },
+        "bookmarks_tags_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "tags",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "gin",
+          "name": "bookmarks_tags_idx",
+          "with": {}
+        },
+        "bookmarks_url_trgm_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "url",
+              "isExpression": false,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "gin",
+          "name": "bookmarks_url_trgm_idx",
+          "with": {}
+        },
+        "bookmarks_user_created_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": false,
+              "expression": "created_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "bookmarks_user_created_at_idx",
+          "with": {}
+        },
+        "bookmarks_user_status_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "status",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "bookmarks_user_status_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "bookmarks",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.feeds": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "identity": {
+            "cache": "1",
+            "cycle": false,
+            "increment": "1",
+            "maxValue": "9223372036854775807",
+            "minValue": "1",
+            "name": "Feeds_id_seq",
+            "schema": "public",
+            "startWith": "1",
+            "type": "byDefault"
+          },
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "bigint"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "properties": {
+          "name": "properties",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "type": {
+          "name": "type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "feeds_type",
+          "typeSchema": "public"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "feeds",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.jwks": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "private_key": {
+          "name": "private_key",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "public_key": {
+          "name": "public_key",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "jwks",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.media": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "identity": {
+            "cache": "1",
+            "cycle": false,
+            "increment": "1",
+            "maxValue": "9223372036854775807",
+            "minValue": "1",
+            "name": "media_id_seq",
+            "schema": "public",
+            "startWith": "1",
+            "type": "byDefault"
+          },
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "bigint"
+        },
+        "image": {
+          "name": "image",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "media_id": {
+          "name": "media_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "name": {
+          "default": "''",
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "platform": {
+          "name": "platform",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "rating": {
+          "name": "rating",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "media_rating",
+          "typeSchema": "public"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "numeric"
+        },
+        "status": {
+          "default": "'wishlist'",
+          "name": "status",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "media_status",
+          "typeSchema": "public"
+        },
+        "type": {
+          "name": "type",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "media_type",
+          "typeSchema": "public"
+        },
+        "user": {
+          "name": "user",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "media_user_user_id_fk": {
+          "columnsFrom": ["user"],
+          "columnsTo": ["id"],
+          "name": "media_user_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "media",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "media_user_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "media_user_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "media",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.oauth_access_token": {
+      "checkConstraints": {},
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "scopes": {
+          "name": "scopes",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "session_id": {
+          "name": "session_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "client_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_access_token_client_id_idx",
+          "with": {}
+        },
+        "oauth_access_token_session_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "session_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_access_token_session_id_idx",
+          "with": {}
+        },
+        "oauth_access_token_token_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "token",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "oauth_access_token_token_key",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_access_token_user_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "oauth_access_token",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.oauth_client": {
+      "checkConstraints": {},
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "contacts": {
+          "name": "contacts",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "disabled": {
+          "default": false,
+          "name": "disabled",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "icon": {
+          "name": "icon",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "metadata": {
+          "name": "metadata",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "name": {
+          "name": "name",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "policy": {
+          "name": "policy",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "public": {
+          "name": "public",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "response_types": {
+          "name": "response_types",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "scopes": {
+          "name": "scopes",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "software_id": {
+          "name": "software_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "software_version": {
+          "name": "software_version",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "tos": {
+          "name": "tos",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "type": {
+          "name": "type",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "uri": {
+          "name": "uri",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "oauth_client_user_id_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_client",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "client_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "oauth_client_client_id_key",
+          "with": {}
+        },
+        "oauth_client_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_client_user_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "oauth_client",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.oauth_consent": {
+      "checkConstraints": {},
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "scopes": {
+          "name": "scopes",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "oauth_consent_user_id_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "client_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_consent_client_id_idx",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_consent_user_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "oauth_consent",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.oauth_refresh_token": {
+      "checkConstraints": {},
+      "columns": {
+        "auth_time": {
+          "name": "auth_time",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "client_id": {
+          "name": "client_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "revoked": {
+          "name": "revoked",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "scopes": {
+          "name": "scopes",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "session_id": {
+          "name": "session_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "client_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_refresh_token_client_id_idx",
+          "with": {}
+        },
+        "oauth_refresh_token_session_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "session_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_refresh_token_session_id_idx",
+          "with": {}
+        },
+        "oauth_refresh_token_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "oauth_refresh_token_user_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "oauth_refresh_token",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.profiles": {
+      "checkConstraints": {
+        "username_length": {
+          "name": "username_length",
+          "value": "char_length(\"profiles\".\"username\") >= 3"
+        }
+      },
+      "columns": {
+        "api_key": {
+          "default": "gen_random_uuid()",
+          "name": "api_key",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "settings_collections_visible": {
+          "default": false,
+          "name": "settings_collections_visible",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "settings_group_by_date": {
+          "default": false,
+          "name": "settings_group_by_date",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "settings_pinned_tags": {
+          "default": "ARRAY[]::text[]",
+          "name": "settings_pinned_tags",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "settings_tags_visible": {
+          "default": false,
+          "name": "settings_tags_visible",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "settings_top_tags_count": {
+          "name": "settings_top_tags_count",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "numeric"
+        },
+        "settings_types_visible": {
+          "default": false,
+          "name": "settings_types_visible",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "username": {
+          "name": "username",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "profiles_id_user_id_fk": {
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "name": "profiles_id_user_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "profiles",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "profiles_api_key_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "api_key",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "profiles_api_key_key",
+          "with": {}
+        },
+        "profiles_username_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "username",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "profiles_username_key",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "profiles",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.session": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "session_user_id_user_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "session",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "session_token_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "token",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "session_token_key",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "session_user_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "session",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.shares": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "kind": {
+          "name": "kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "share_kind",
+          "typeSchema": "public"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "shares_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "shares_user_id_user_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "shares",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "shares_token_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "token",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "shares_token_key",
+          "with": {}
+        },
+        "shares_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "shares_user_id_idx",
+          "with": {}
+        },
+        "shares_user_kind_name_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "name",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "shares_user_kind_name_key",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "shares",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "checkConstraints": {},
+      "columns": {
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "tag": {
+          "name": "tag",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "tags_tag_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "tag",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "tags_tag_key",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "tags",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.toots": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "db_user_id": {
+          "name": "db_user_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "liked_toot": {
+          "default": false,
+          "name": "liked_toot",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "media": {
+          "name": "media",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "reply": {
+          "name": "reply",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "text": {
+          "default": "''",
+          "name": "text",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "toot_id": {
+          "name": "toot_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "toot_url": {
+          "name": "toot_url",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "urls": {
+          "name": "urls",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "user_avatar": {
+          "name": "user_avatar",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_name": {
+          "name": "user_name",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "toots_db_user_id_user_id_fk": {
+          "columnsFrom": ["db_user_id"],
+          "columnsTo": ["id"],
+          "name": "toots_db_user_id_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "toots",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "toots_db_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "db_user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "toots_db_user_id_idx",
+          "with": {}
+        },
+        "toots_toot_id_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "toot_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "toots_toot_id_key",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "toots",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.tweets": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "db_user_id": {
+          "name": "db_user_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text[]"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "liked_tweet": {
+          "default": false,
+          "name": "liked_tweet",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "media": {
+          "name": "media",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "reply": {
+          "name": "reply",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "text": {
+          "default": "''",
+          "name": "text",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "tweet_id": {
+          "name": "tweet_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "tweet_url": {
+          "name": "tweet_url",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "urls": {
+          "name": "urls",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "user_avatar": {
+          "name": "user_avatar",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_name": {
+          "name": "user_name",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "tweets_db_user_id_user_id_fk": {
+          "columnsFrom": ["db_user_id"],
+          "columnsTo": ["id"],
+          "name": "tweets_db_user_id_user_id_fk",
+          "onDelete": "no action",
+          "onUpdate": "no action",
+          "tableFrom": "tweets",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {
+        "tweets_db_user_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "db_user_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "tweets_db_user_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "tweets",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.user": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "email": {
+          "name": "email",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "email_verified": {
+          "default": false,
+          "name": "email_verified",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "image": {
+          "name": "image",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "user_email_key": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "email",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "user_email_key",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "user",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.user_integrations": {
+      "checkConstraints": {},
+      "columns": {
+        "bluesky_app_password": {
+          "name": "bluesky_app_password",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "bluesky_enabled": {
+          "default": false,
+          "name": "bluesky_enabled",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "bluesky_handle": {
+          "name": "bluesky_handle",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "bluesky_last_error": {
+          "name": "bluesky_last_error",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "bluesky_post_prefix": {
+          "name": "bluesky_post_prefix",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "bluesky_post_suffix": {
+          "name": "bluesky_post_suffix",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "user_integrations_user_id_user_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "user_integrations_user_id_user_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "user_integrations",
+          "tableTo": "user"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "user_integrations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.verification": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()::text",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "identifier": {
+          "name": "identifier",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "value": {
+          "name": "value",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "verification",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
+}

--- a/packages/web/drizzle/meta/0003_snapshot.json
+++ b/packages/web/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,2412 @@
+{
+  "id": "1c0947b9-c743-4df2-8ee1-1adaf585e0f6",
+  "prevId": "a7af9296-a811-4810-81cd-0f24a3ebaa63",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_key": {
+          "name": "user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmark_tags": {
+      "name": "bookmark_tags",
+      "schema": "",
+      "columns": {
+        "bookmark_id": {
+          "name": "bookmark_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookmark_tags_bookmark_id_bookmarks_id_fk": {
+          "name": "bookmark_tags_bookmark_id_bookmarks_id_fk",
+          "tableFrom": "bookmark_tags",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmark_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookmark_tags_tag_id_tags_id_fk": {
+          "name": "bookmark_tags_tag_id_tags_id_fk",
+          "tableFrom": "bookmark_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmark_tags_pkey": {
+          "name": "bookmark_tags_pkey",
+          "columns": [
+            "bookmark_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "bluesky_post_uri": {
+          "name": "bluesky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_count": {
+          "name": "click_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc', now())"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed": {
+          "name": "feed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc', now())"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"bookmarks\".\"title\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"bookmarks\".\"description\", '')), 'B') || setweight(to_tsvector('english', coalesce(\"bookmarks\".\"note\", '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "star": {
+          "name": "star",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tweet": {
+          "name": "tweet",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'link'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user": {
+          "name": "user",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bookmarks_user_created_at_idx": {
+          "name": "bookmarks_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_status_idx": {
+          "name": "bookmarks_user_status_idx",
+          "columns": [
+            {
+              "expression": "user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_public_status_created_at_idx": {
+          "name": "bookmarks_public_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_search_text_idx": {
+          "name": "bookmarks_search_text_idx",
+          "columns": [
+            {
+              "expression": "search_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bookmarks_tags_idx": {
+          "name": "bookmarks_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bookmarks_url_trgm_idx": {
+          "name": "bookmarks_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_user_id_fk": {
+          "name": "bookmarks_user_user_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feeds": {
+      "name": "feeds",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "Feeds_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feeds_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "media_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "media_rating",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "media_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'wishlist'"
+        },
+        "type": {
+          "name": "type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user": {
+          "name": "user",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_user_idx": {
+          "name": "media_user_idx",
+          "columns": [
+            {
+              "expression": "user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_user_user_id_fk": {
+          "name": "media_user_user_id_fk",
+          "tableFrom": "media",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token_key": {
+          "name": "oauth_access_token_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_id_idx": {
+          "name": "oauth_access_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_key": {
+          "name": "oauth_client_client_id_key",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_client_user_id_idx": {
+          "name": "oauth_client_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_id_idx": {
+          "name": "oauth_refresh_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_id_idx": {
+          "name": "oauth_refresh_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_id_idx": {
+          "name": "oauth_refresh_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "api_key": {
+          "name": "api_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "settings_collections_visible": {
+          "name": "settings_collections_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings_group_by_date": {
+          "name": "settings_group_by_date",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "settings_pinned_tags": {
+          "name": "settings_pinned_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "settings_tags_visible": {
+          "name": "settings_tags_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings_top_tags_count": {
+          "name": "settings_top_tags_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_types_visible": {
+          "name": "settings_types_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_api_key_key": {
+          "name": "profiles_api_key_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_username_key": {
+          "name": "profiles_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_id_user_id_fk": {
+          "name": "profiles_id_user_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "username_length": {
+          "name": "username_length",
+          "value": "char_length(\"profiles\".\"username\") >= 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shares": {
+      "name": "shares",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "share_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "shares_token_key": {
+          "name": "shares_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shares_user_kind_name_key": {
+          "name": "shares_user_kind_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shares_user_id_idx": {
+          "name": "shares_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shares_user_id_user_id_fk": {
+          "name": "shares_user_id_user_id_fk",
+          "tableFrom": "shares",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_tag_key": {
+          "name": "tags_tag_key",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toots": {
+      "name": "toots",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "db_user_id": {
+          "name": "db_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "liked_toot": {
+          "name": "liked_toot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "media": {
+          "name": "media",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply": {
+          "name": "reply",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "toot_id": {
+          "name": "toot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toot_url": {
+          "name": "toot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls": {
+          "name": "urls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_avatar": {
+          "name": "user_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "toots_toot_id_key": {
+          "name": "toots_toot_id_key",
+          "columns": [
+            {
+              "expression": "toot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "toots_db_user_id_idx": {
+          "name": "toots_db_user_id_idx",
+          "columns": [
+            {
+              "expression": "db_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "toots_db_user_id_user_id_fk": {
+          "name": "toots_db_user_id_user_id_fk",
+          "tableFrom": "toots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "db_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tweets": {
+      "name": "tweets",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "db_user_id": {
+          "name": "db_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "liked_tweet": {
+          "name": "liked_tweet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "media": {
+          "name": "media",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply": {
+          "name": "reply",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "tweet_id": {
+          "name": "tweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tweet_url": {
+          "name": "tweet_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls": {
+          "name": "urls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_avatar": {
+          "name": "user_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tweets_db_user_id_idx": {
+          "name": "tweets_db_user_id_idx",
+          "columns": [
+            {
+              "expression": "db_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tweets_db_user_id_user_id_fk": {
+          "name": "tweets_db_user_id_user_id_fk",
+          "tableFrom": "tweets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "db_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_integrations": {
+      "name": "user_integrations",
+      "schema": "",
+      "columns": {
+        "bluesky_app_password": {
+          "name": "bluesky_app_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bluesky_enabled": {
+          "name": "bluesky_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bluesky_handle": {
+          "name": "bluesky_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bluesky_last_error": {
+          "name": "bluesky_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bluesky_post_prefix": {
+          "name": "bluesky_post_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bluesky_post_suffix": {
+          "name": "bluesky_post_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_integrations_user_id_user_id_fk": {
+          "name": "user_integrations_user_id_user_id_fk",
+          "tableFrom": "user_integrations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.type": {
+      "name": "type",
+      "schema": "public",
+      "values": [
+        "link",
+        "video",
+        "audio",
+        "recipe",
+        "image",
+        "document",
+        "article",
+        "game",
+        "book",
+        "event",
+        "product",
+        "note",
+        "file",
+        "place"
+      ]
+    },
+    "public.feeds_type": {
+      "name": "feeds_type",
+      "schema": "public",
+      "values": [
+        "rss",
+        "api"
+      ]
+    },
+    "public.media_rating": {
+      "name": "media_rating",
+      "schema": "public",
+      "values": [
+        "0",
+        "0.5",
+        "1",
+        "1.5",
+        "2",
+        "2.5",
+        "3",
+        "3.5",
+        "4",
+        "4.5",
+        "5"
+      ]
+    },
+    "public.media_status": {
+      "name": "media_status",
+      "schema": "public",
+      "values": [
+        "now",
+        "skipped",
+        "done",
+        "wishlist"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "tv",
+        "film",
+        "game",
+        "book",
+        "podcast",
+        "music",
+        "other"
+      ]
+    },
+    "public.share_kind": {
+      "name": "share_kind",
+      "schema": "public",
+      "values": [
+        "tag",
+        "collection"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -21,6 +21,13 @@
       "tag": "0002_search",
       "version": "7",
       "when": 1781045049789
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781089918509,
+      "tag": "0003_dear_stryfe",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -14,6 +14,13 @@
       "tag": "0001_shares",
       "version": "7",
       "when": 1778500000000
+    },
+    {
+      "breakpoints": true,
+      "idx": 2,
+      "tag": "0002_search",
+      "version": "7",
+      "when": 1781045049789
     }
   ],
   "version": "7"

--- a/packages/web/worker/mcp/tools.ts
+++ b/packages/web/worker/mcp/tools.ts
@@ -1,4 +1,13 @@
-import { and, arrayContains, count, desc, eq, ilike, or } from 'drizzle-orm'
+import {
+  and,
+  arrayContains,
+  count,
+  desc,
+  eq,
+  ilike,
+  or,
+  sql,
+} from 'drizzle-orm'
 import { TidyURL } from 'tidy-url'
 import type { BookmarkStatus, BookmarkType } from '@/types/db'
 import { matchTagsSource } from '@/utils/matchTags'
@@ -107,10 +116,8 @@ const bookmarkFilters = (
     args.tag ? arrayContains(bookmarks.tags, [args.tag as string]) : undefined,
     searchTerm
       ? or(
-          ilike(bookmarks.title, `%${searchTerm}%`),
+          sql`${bookmarks.searchText} @@ websearch_to_tsquery('english', ${searchTerm})`,
           ilike(bookmarks.url, `%${searchTerm}%`),
-          ilike(bookmarks.description, `%${searchTerm}%`),
-          ilike(bookmarks.note, `%${searchTerm}%`),
           arrayContains(bookmarks.tags, [searchTerm]),
         )
       : undefined,
@@ -136,7 +143,14 @@ const listBookmarkRows = async (
     .orderBy(
       ...(top
         ? [desc(bookmarks.clickCount), desc(bookmarks.createdAt)]
-        : [desc(bookmarks.createdAt)]),
+        : searchTerm
+          ? [
+              desc(
+                sql`ts_rank(${bookmarks.searchText}, websearch_to_tsquery('english', ${searchTerm}))`,
+              ),
+              desc(bookmarks.createdAt),
+            ]
+          : [desc(bookmarks.createdAt)]),
     )
     .limit(limit)
     .offset(offset)

--- a/packages/web/worker/search/search.ts
+++ b/packages/web/worker/search/search.ts
@@ -5,8 +5,10 @@ import {
   count,
   desc,
   eq,
+  getTableColumns,
   ilike,
   or,
+  sql,
 } from 'drizzle-orm'
 import type { Context } from 'hono'
 import { API_HEADERS, DEFAULT_API_RESPONSE_LIMIT } from '@/constants'
@@ -52,35 +54,55 @@ export const getSearch = async (context: HonoContext) => {
       status,
       type,
     } = apiParameters(searchParams)
-    const pattern = `%${searchTerm}%`
+    const hasSearchTerm = searchTerm.trim() !== ''
+    const tsQuery = sql`websearch_to_tsquery('english', ${searchTerm})`
     const where = and(
       eq(bookmarks.user, userId),
       status ? eq(bookmarks.status, status) : undefined,
       type ? eq(bookmarks.type, type as BookmarkType) : undefined,
-      or(
-        ilike(bookmarks.title, pattern),
-        ilike(bookmarks.url, pattern),
-        ilike(bookmarks.description, pattern),
-        ilike(bookmarks.note, pattern),
-        searchTerm ? arrayContains(bookmarks.tags, [searchTerm]) : undefined,
-      ),
+      hasSearchTerm
+        ? or(
+            sql`${bookmarks.searchText} @@ ${tsQuery}`,
+            ilike(bookmarks.url, `%${searchTerm}%`),
+            arrayContains(bookmarks.tags, [searchTerm]),
+          )
+        : undefined,
     )
-    const [{ value: total }] = await requestContext.db
-      .select({ value: count() })
+    const orderBy =
+      order === 'asc'
+        ? [asc(bookmarks.createdAt)]
+        : hasSearchTerm
+          ? [
+              desc(sql`ts_rank(${bookmarks.searchText}, ${tsQuery})`),
+              desc(bookmarks.createdAt),
+            ]
+          : [desc(bookmarks.createdAt)]
+    const rows = await requestContext.db
+      .select({
+        ...getTableColumns(bookmarks),
+        fullCount: sql`count(*) over ()`.mapWith(Number),
+      })
       .from(bookmarks)
       .where(where)
-    const data = await requestContext.db
-      .select()
-      .from(bookmarks)
-      .where(where)
-      .orderBy(
-        order === 'asc' ? asc(bookmarks.createdAt) : desc(bookmarks.createdAt),
-      )
+      .orderBy(...orderBy)
       .limit(limit)
       .offset(offset)
+    let total = rows[0]?.fullCount ?? 0
+
+    // An offset past the last row returns no rows (and no window count) even
+    // when there are matches — fall back to a count query so pagination
+    // metadata stays correct.
+    if (rows.length === 0 && offset > 0) {
+      const [{ value }] = await requestContext.db
+        .select({ value: count() })
+        .from(bookmarks)
+        .where(where)
+      total = value ?? 0
+    }
+
     const responseBody = apiResponseGenerator({
-      count: total ?? 0,
-      data: data.map(bookmarkToRow),
+      count: total,
+      data: rows.map(bookmarkToRow),
       limit,
       offset,
       path: context.req.url,


### PR DESCRIPTION
## Why

Bookmark search ran `ILIKE '%term%'` across four text columns plus a tag-array containment check. None of those predicates can use an index — leading-wildcard `ILIKE` is unindexable with btree, and `tags @> …` needs GIN — so every search filtered every row the user owns, twice (once for the count, once for the data).

## What changed

**Schema (`db/schema.ts` + migration `0002_search.sql`)**
- New stored generated `tsvector` column `search_text` on `bookmarks`, combining title (weight A), description (B) and note (C), with a GIN index.
- `pg_trgm` GIN index on `url` so the existing substring matching on URLs becomes indexable (also speeds up the duplicate-URL check in `bookmarks/item.ts`).
- GIN index on the `tags` array — accelerates tag containment everywhere it's used (search, tag filtering in `getAllBookmarks`, shares).
- Replaced the standalone `user` / `status` btree indexes with composite `(user, created_at DESC)` and `(user, status)` indexes that match the actual query shapes.

**`/api/search` (`worker/search/search.ts`)**
- Title/description/note matching now uses `search_text @@ websearch_to_tsquery('english', q)` — word stemming, sensible multi-word AND semantics. URL keeps `ILIKE` substring semantics; tags keep exact match.
- Results are ordered by `ts_rank` relevance (then recency) unless `order=asc` is requested.
- The separate `count()` query is folded into the data query via `count(*) OVER ()`, halving DB round trips; a fallback count query keeps pagination metadata correct when an offset lands past the last row.

**MCP `search_bookmarks` (`worker/mcp/tools.ts`)**
- Same FTS predicate and rank-aware ordering.

## Behaviour notes

- Searches now match whole words/stems in title/description/note ("cooking" finds "cook"), not arbitrary substrings ("ook" no longer matches "book"). URL search keeps substring behaviour.
- The migration enables the `pg_trgm` extension (`CREATE EXTENSION IF NOT EXISTS`), available on Supabase and standard Postgres.
- While generating the migration I found `drizzle/meta/0001_snapshot.json` was never committed alongside the `0001_shares` migration, so drizzle-kit re-emitted the shares DDL; I stripped that from the generated SQL by hand. The new `0002_snapshot.json` includes shares, so future `db:generate` runs will diff cleanly.

## Testing

- `tsc -b` clean, `pnpm vitest run` 15/15 passing, biome clean on the changed files.
- Not run against a live database in this environment — worth running `pnpm db:migrate` and a couple of searches against a staging DB before merging.

https://claude.ai/code/session_01ENcRvgzqfVXNzRUWhTAmUG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENcRvgzqfVXNzRUWhTAmUG)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced multi‑column ILIKE bookmark search with Postgres full‑text search and added GIN/TRGM indexes. Searches are faster, ranked by relevance, and avoid full table scans; URL substring matching is preserved, and public feed queries are now indexed.

- **New Features**
  - Use full‑text search over title/description/note with `ts_rank` relevance, then recency; keep URL substring and exact tag matches.
  - Add GIN on `search_text` and `tags`, `pg_trgm` GIN on `url`; replace per‑column indexes with composite `(user, created_at DESC)`, `(user, status)`, and `(public, status, created_at DESC)` for the public feed.
  - Fold count into the data query via `count(*) OVER ()` with a fallback for past‑end offsets; MCP `search_bookmarks` uses the same FTS and ordering.

- **Migration**
  - Run migrations `0002_search` and `0003_dear_stryfe`.
  - Search now matches word stems in title/description/note; URL search remains substring‑based.

<sup>Written for commit a084de6c2929d1049d716d980f4509bea68cf721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/Otter/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

