### PR TITLE
Fix media form resets, separate search field, better book API, kanban polish

### DIFF
--- a/packages/web/.dev.vars.example
+++ b/packages/web/.dev.vars.example
@@ -16,6 +16,10 @@ VITE_ALLOW_SIGNUP=false
 RAYCAST_OAUTH_CLIENT_ID=
 
 # Optional integrations
+# Google Books API key for book search (free: https://console.cloud.google.com/apis/library/books.googleapis.com)
+MEDIA_GOOGLE_BOOKS_API_KEY=
+# GameBrain API key for game search (https://gamebrain.co)
+MEDIA_GAMEBRAIN_API_KEY=
 BOT_MASTODON_ACCESS_TOKEN=
 PERSONAL_MASTODON_ACCESS_TOKEN=
 WEBHOOK_SECRET=replace-with-a-random-secret

--- a/packages/web/.env.local.example
+++ b/packages/web/.env.local.example
@@ -15,6 +15,10 @@ VITE_ALLOW_SIGNUP=false
 RAYCAST_OAUTH_CLIENT_ID=
 
 # Optional integrations
+# Google Books API key for book search (free: https://console.cloud.google.com/apis/library/books.googleapis.com)
+MEDIA_GOOGLE_BOOKS_API_KEY=
+# GameBrain API key for game search (https://gamebrain.co)
+MEDIA_GAMEBRAIN_API_KEY=
 BOT_MASTODON_ACCESS_TOKEN=
 PERSONAL_MASTODON_ACCESS_TOKEN=
 WEBHOOK_SECRET=

--- a/packages/web/src/components/MediaCard.tsx
+++ b/packages/web/src/components/MediaCard.tsx
@@ -61,9 +61,8 @@ export const MediaCard = ({
     >
       {media.image ? (
         <img src={media.image} alt={media.name} className="rounded-md" />
-      ) : (
-        <div className="media-card-title">{media.name}</div>
-      )}
+      ) : null}
+      <div className="media-card-title">{media.name}</div>
 
       {media.rating ? <Rating rating={media.rating} /> : null}
 

--- a/packages/web/src/components/MediaColumn.css
+++ b/packages/web/src/components/MediaColumn.css
@@ -1,0 +1,53 @@
+.media-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 400px;
+  max-height: calc(100dvh - 16rem);
+  border-radius: var(--radii-l);
+  background-color: var(--theme2);
+  border: 1px solid var(--border);
+  transition:
+    background-color 150ms var(--ease-in-out-1),
+    border-color 150ms var(--ease-in-out-1);
+}
+
+.media-column-drop-target {
+  border-color: var(--theme8);
+  background-color: var(--theme3);
+}
+
+.media-column-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-xs) var(--space-s);
+  border-bottom: 1px solid var(--border);
+}
+
+.media-column-count {
+  font-size: var(--step--1);
+  color: var(--theme10);
+  background-color: var(--theme4);
+  border-radius: var(--radii-pill, 999px);
+  padding: 0 var(--space-2xs);
+  min-width: 1.5em;
+  text-align: center;
+}
+
+.media-column-items {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-xs);
+}
+
+.media-column-empty {
+  border: 1px dashed var(--theme7);
+  border-radius: var(--radii-m);
+  padding: var(--space-l) var(--space-s);
+  text-align: center;
+  color: var(--theme10);
+  font-size: var(--step--1);
+}

--- a/packages/web/src/components/MediaColumn.tsx
+++ b/packages/web/src/components/MediaColumn.tsx
@@ -1,23 +1,29 @@
 import { CollisionPriority } from '@dnd-kit/abstract'
 import { useDroppable } from '@dnd-kit/react'
+import { PlusIcon } from '@phosphor-icons/react'
 import type { ComponentProps } from 'react'
 import titleFmt from 'title'
 import type { Media, MediaStatus } from '@/types/db'
 import { cn } from '@/utils/classnames'
+import { IconButton } from './IconButton'
 import { MediaCard } from './MediaCard'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './Tooltip'
 
-const getStatusColor = (status: string) => {
+const getStatusDotColor = (status: string) => {
   switch (status) {
     case 'wishlist':
-      return 'border-blue-200 text-blue-200'
+      return 'bg-blue-400'
     case 'now':
-      return 'border-green-200 text-green-200'
-    // case 'skipped':
-    //   return 'border-yellow-200 text-yellow-200'
+      return 'bg-green-400'
     case 'done':
-      return 'border-purple-200 text-purple-200'
+      return 'bg-purple-400'
     default:
-      return 'border-gray-200 text-gray-200'
+      return 'bg-gray-400'
   }
 }
 
@@ -26,6 +32,7 @@ interface MediaColumnProps extends ComponentProps<'div'> {
   media: Media[]
   title: string
   onEdit?: (media: Media) => void
+  onAdd?: (status: MediaStatus) => void
 }
 
 export const MediaColumn = ({
@@ -34,6 +41,7 @@ export const MediaColumn = ({
   title,
   className,
   onEdit,
+  onAdd,
   ...rest
 }: MediaColumnProps) => {
   const { isDropTarget, ref } = useDroppable({
@@ -43,39 +51,58 @@ export const MediaColumn = ({
     type: 'column',
   })
 
-  const isOverContainer = isDropTarget
-
   return (
     <div
       ref={ref}
       className={cn(
-        'media-column flex flex-col gap-4 h-full min-h-[500px]',
+        'media-column',
+        isDropTarget && 'media-column-drop-target',
         className,
       )}
       {...rest}
     >
-      <div className={cn('column-header p-2 border-b', getStatusColor(status))}>
-        <h3 className="font-semibold text-lg">{titleFmt(title)}</h3>
-        <span className="text-sm text-gray-500 dark:text-gray-400">
-          {media.length} items
-        </span>
+      <div className="media-column-header">
+        <span
+          className={cn(
+            'size-2.5 rounded-full shrink-0',
+            getStatusDotColor(status),
+          )}
+        />
+        <h3 className="font-semibold">{titleFmt(title)}</h3>
+        <span className="media-column-count">{media.length}</span>
+        {onAdd ? (
+          <TooltipProvider delayDuration={800}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton
+                  size="s"
+                  className="ml-auto"
+                  onClick={() => onAdd(status)}
+                  aria-label={`Add item to ${title}`}
+                >
+                  <PlusIcon size={16} weight="duotone" />
+                </IconButton>
+              </TooltipTrigger>
+              <TooltipContent>Add item to {titleFmt(title)}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : null}
       </div>
 
-      <div className="flex-1 overflow-y-auto">
-        <div className={cn('space-y-3', { 'bg-gray-400': isOverContainer })}>
-          {media.map((item) => (
-            <MediaCard
-              key={item.id}
-              media={item}
-              onEdit={onEdit}
-              status={status}
-            />
-          ))}
-        </div>
+      <div className="media-column-items">
+        {media.map((item) => (
+          <MediaCard
+            key={item.id}
+            media={item}
+            onEdit={onEdit}
+            status={status}
+          />
+        ))}
 
         {media.length === 0 ? (
-          <div className="text-center text-base py-8">
-            No items in this column
+          <div className="media-column-empty">
+            Nothing here yet — drag an item over
+            {onAdd ? ' or hit the + above' : ''}
           </div>
         ) : null}
       </div>

--- a/packages/web/src/components/MediaForm.css
+++ b/packages/web/src/components/MediaForm.css
@@ -4,6 +4,18 @@
 
 .media-form-columns {
   display: grid;
-  grid-template-columns: 100px 2fr 1.5fr;
-  gap: var(--spacing-s);
+  grid-template-columns: 3fr 2fr;
+  gap: var(--space-m);
+  align-items: start;
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.media-form-search {
+  padding: var(--space-xs);
+  border-radius: var(--radii-m);
+  background-color: var(--theme2);
+  border: 1px solid var(--border);
 }

--- a/packages/web/src/components/MediaForm.tsx
+++ b/packages/web/src/components/MediaForm.tsx
@@ -1,5 +1,5 @@
-import { useSuspenseQuery } from '@tanstack/react-query'
-import type { ComponentProps } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { type ComponentProps, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useDebounceValue } from 'usehooks-ts'
 import { Button } from '@/components/Button'
@@ -7,7 +7,8 @@ import { Combobox } from '@/components/Combobox'
 import { Flex } from '@/components/Flex'
 import { FormGroup } from '@/components/FormGroup'
 import { Input } from '@/components/Input'
-import type { MediaInsert, MediaStatus } from '@/types/db'
+import type { MediaInsert, MediaStatus, MediaType } from '@/types/db'
+import { cn } from '@/utils/classnames'
 import { getMediaSearchOptions } from '@/utils/fetching/media'
 import { IconControl } from './IconControl'
 import {
@@ -36,6 +37,9 @@ export const setComboboxValue = (
   }))
 }
 
+// Types with a search backend in /api/media-search
+const searchableTypes: MediaType[] = ['tv', 'book', 'game', 'podcast']
+
 interface MediaFormProps extends Omit<ComponentProps<'div'>, 'id'> {
   type: 'new' | 'edit'
   initialValues?: Partial<MediaInsert>
@@ -58,6 +62,7 @@ export const MediaForm = ({
   const { register, handleSubmit, setValue, watch } = useForm<MediaInsert>({
     defaultValues: {
       name: '',
+      sort_order: 0,
       status: 'wishlist',
       type: 'tv',
       ...initialValues,
@@ -66,16 +71,24 @@ export const MediaForm = ({
 
   const watchPlatform = watch('platform')
   const watchType = watch('type')
-  const watchName = watch('name')
-  const [debouncedName] = useDebounceValue(watchName, 1000)
-  const { data: mediaSearch } = useSuspenseQuery(
+  const watchStatus = watch('status')
+  const watchImage = watch('image')
+  const watchMediaId = watch('media_id')
+
+  // The catalogue search has its own field, separate from the item name
+  const [searchTerm, setSearchTerm] = useState('')
+  const [debouncedSearchTerm] = useDebounceValue(searchTerm, 500)
+  const trimmedSearchTerm = debouncedSearchTerm.trim()
+  const isSearchableType = !!watchType && searchableTypes.includes(watchType)
+
+  const { data: mediaSearch, isFetching: isSearching } = useQuery(
     getMediaSearchOptions({
-      query: debouncedName,
+      query: isSearchableType ? trimmedSearchTerm : undefined,
       type: watchType,
     }),
   )
 
-  const limitedMediaSearch = mediaSearch?.data?.slice(0, 3)
+  const searchResults = mediaSearch?.data?.slice(0, 5)
 
   const transformedPlatformsForCombobox = platforms.map((platform) => ({
     label: platform,
@@ -97,7 +110,10 @@ export const MediaForm = ({
         onSubmit={handleSubmit(handleSubmitForm)}
         className="flex flex-col gap-s"
       >
-        <input type="hidden" {...register('sort_order')} value={0} />
+        <input
+          type="hidden"
+          {...register('sort_order', { valueAsNumber: true })}
+        />
         <input type="hidden" {...register('image')} />
         <input type="hidden" {...register('media_id')} />
         {/* TYPE */}
@@ -126,16 +142,8 @@ export const MediaForm = ({
             ))}
           </Flex>
         </FormGroup>
-        <div className="media-form-columns">
-          <div>
-            <img
-              src={watch('image') ?? ''}
-              alt={watch('name')}
-              width={100}
-              className="rounded-xs"
-            />
-          </div>
 
+        <div className="media-form-columns">
           <div className="flex flex-col gap-s">
             {/* NAME */}
             <FormGroup label="Name" name="name">
@@ -147,6 +155,29 @@ export const MediaForm = ({
                 autoComplete="off"
               />
             </FormGroup>
+
+            {/* COVER PREVIEW */}
+            {watchImage ? (
+              <Flex gap="xs" align="center">
+                <img
+                  src={watchImage}
+                  alt={watch('name') || 'Cover preview'}
+                  width={72}
+                  className="rounded-xs"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="2xs"
+                  onClick={() => {
+                    setValue('image', null)
+                    setValue('media_id', null)
+                  }}
+                >
+                  Remove image
+                </Button>
+              </Flex>
+            ) : null}
 
             {/* PLATFORM */}
             <FormGroup label="Platform" name="platform">
@@ -172,7 +203,7 @@ export const MediaForm = ({
             {/* STATUS */}
             <FormGroup label="Status" name="status">
               <Select
-                {...register('status')}
+                value={watchStatus ?? 'wishlist'}
                 onValueChange={(value) => {
                   setValue('status', value as MediaStatus)
                 }}
@@ -223,38 +254,68 @@ export const MediaForm = ({
             </FormGroup>
           </div>
 
-          <div className="flex flex-col gap-s">
-            {limitedMediaSearch?.length ? (
-              limitedMediaSearch?.map((item) => {
-                return (
-                  <Button
-                    variant="outline"
-                    key={item.id}
-                    className="px-s justify-start"
-                    onClick={() => {
-                      setValue('name', item.title)
-                      setValue('media_id', item.id)
-                      setValue('image', item.image)
-                    }}
-                    type="button"
-                  >
-                    <img
-                      src={item.image}
-                      alt={item.title}
-                      width={50}
-                      className="rounded-xs shrink-0"
-                    />
-                    <div className="flex flex-col gap-xs text-sm text-left">
-                      <div>{item.title}</div>
-                      {item?.maker ? <div>{item.maker}</div> : null}
-                    </div>
-                  </Button>
-                )
-              })
-            ) : (
-              <div>No results found</div>
-            )}
-          </div>
+          {/* SEARCH */}
+          {isSearchableType ? (
+            <div className="media-form-search flex flex-col gap-s">
+              <FormGroup
+                label="Search"
+                name="media-search"
+                note={`Search for a ${watchType} to fill in the name and cover image`}
+              >
+                <Input
+                  id="media-search"
+                  type="search"
+                  placeholder={`Find a ${watchType}…`}
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
+                  autoComplete="off"
+                />
+              </FormGroup>
+
+              {searchResults?.length ? (
+                <div className="flex flex-col gap-xs">
+                  {searchResults.map((item) => {
+                    const isSelected = watchMediaId === String(item.id)
+                    return (
+                      <Button
+                        variant="outline"
+                        key={item.id}
+                        className={cn(
+                          'px-s justify-start h-auto',
+                          isSelected && 'border-[var(--accent9)]',
+                        )}
+                        aria-pressed={isSelected}
+                        onClick={() => {
+                          setValue('name', item.title)
+                          setValue('media_id', String(item.id))
+                          setValue('image', item.image)
+                        }}
+                        type="button"
+                      >
+                        <img
+                          src={item.image}
+                          alt={item.title}
+                          width={40}
+                          className="rounded-xs shrink-0"
+                        />
+                        <div className="flex flex-col gap-2xs text-sm text-left">
+                          <div>{item.title}</div>
+                          {item?.maker ? (
+                            <div className="text-muted-foreground">
+                              {item.maker}
+                            </div>
+                          ) : null}
+                        </div>
+                      </Button>
+                    )
+                  })}
+                </div>
+              ) : trimmedSearchTerm && !isSearching ? (
+                <div className="text-sm">No results found</div>
+              ) : null}
+              {isSearching ? <div className="text-sm">Searching…</div> : null}
+            </div>
+          ) : null}
         </div>
 
         <div>

--- a/packages/web/src/routes/_app/media.css
+++ b/packages/web/src/routes/_app/media.css
@@ -1,6 +1,6 @@
 .media-columns {
   display: grid;
-  grid-template-columns: 268px 268px 268px;
+  grid-template-columns: repeat(3, minmax(268px, 1fr));
   gap: var(--space-m);
   overflow-x: auto;
   width: 100dvw;

--- a/packages/web/src/routes/_app/media.tsx
+++ b/packages/web/src/routes/_app/media.tsx
@@ -53,6 +53,7 @@ function RouteComponent() {
   const [filters, setFilters] = useState<MediaFilters>({})
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [editingMedia, setEditingMedia] = useState<Media | null>(null)
+  const [newMediaStatus, setNewMediaStatus] = useState<MediaStatus>('wishlist')
   const { data: mediaResponse } = useSuspenseQuery(getMediaOptions())
   const allMedia = mediaResponse?.data
   const [media, setMedia] = useState(allMedia)
@@ -107,6 +108,12 @@ function RouteComponent() {
 
   const handleEditMedia = (media: Media) => {
     setEditingMedia(media)
+    setIsDialogOpen(true)
+  }
+
+  const handleAddMedia = (status: MediaStatus = 'wishlist') => {
+    setEditingMedia(null)
+    setNewMediaStatus(status)
     setIsDialogOpen(true)
   }
 
@@ -221,15 +228,18 @@ function RouteComponent() {
             }}
           >
             <DialogTrigger asChild>
-              <Button variant="outline">
+              <Button variant="outline" onClick={() => handleAddMedia()}>
                 <PlusCircleIcon size={18} weight="duotone" />
                 Add Media
               </Button>
             </DialogTrigger>
             <DialogContent placement="center" width="m">
               <MediaForm
+                // Remount the form when switching between new/edit targets
+                // so react-hook-form picks up fresh default values
+                key={editingMedia ? editingMedia.id : `new-${newMediaStatus}`}
                 type={editingMedia ? 'edit' : 'new'}
-                initialValues={editingMedia || undefined}
+                initialValues={editingMedia ?? { status: newMediaStatus }}
                 platforms={platforms}
                 onFormSubmit={
                   editingMedia ? handleUpdateMedia : handleCreateMedia
@@ -332,7 +342,8 @@ function RouteComponent() {
                 key={status}
                 status={status}
                 title={title}
-                media={filteredMedia[status]}
+                media={filteredMedia[status] ?? []}
+                onAdd={handleAddMedia}
                 onEdit={handleEditMedia}
               />
             ))}

--- a/packages/web/src/styles/components.css
+++ b/packages/web/src/styles/components.css
@@ -16,6 +16,7 @@
 @import "../components/Link.css";
 @import "../components/Markdown.css";
 @import "../components/MediaCard.css";
+@import "../components/MediaColumn.css";
 @import "../components/MediaForm.css";
 @import "../components/Paragraph.css";
 @import "../components/Sidebar.css";

--- a/packages/web/src/utils/fetching/media.ts
+++ b/packages/web/src/utils/fetching/media.ts
@@ -1,4 +1,5 @@
 import {
+  keepPreviousData,
   queryOptions,
   useMutation,
   useQueryClient,
@@ -26,11 +27,17 @@ type SingleResponse<T> = {
   error: null
 }
 
-const groupMediaByStatus = (media: Media[]) => {
-  return Object.groupBy(
-    media,
-    (item) => item.status ?? 'wishlist',
-  ) as GroupedMedia
+const groupMediaByStatus = (media: Media[]): GroupedMedia => {
+  // Always include every status so empty kanban columns stay present,
+  // and keep each column ordered by sort_order.
+  const grouped: GroupedMedia = { done: [], now: [], skipped: [], wishlist: [] }
+  for (const item of media) {
+    grouped[item.status ?? 'wishlist'].push(item)
+  }
+  for (const items of Object.values(grouped)) {
+    items.sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+  }
+  return grouped
 }
 
 const parseJsonResponse = async <T>(response: Response): Promise<T> => {
@@ -235,12 +242,13 @@ const getMediaSearch = async ({
   query: string
   type: MediaType
 }) => {
-  const response = await fetch(`/api/media-search?query=${query}&type=${type}`)
-  const data = await response.json()
-  return data as {
+  const response = await fetch(
+    `/api/media-search?query=${encodeURIComponent(query)}&type=${type}`,
+  )
+  return await parseJsonResponse<{
     count: number
     data: MediaSearchItem[]
-  }
+  }>(response)
 }
 
 export const getMediaSearchOptions = ({
@@ -252,8 +260,13 @@ export const getMediaSearchOptions = ({
 }) => {
   return queryOptions({
     enabled: !!query && !!type,
-    // @ts-expect-error - This will only run if query and type are defined
-    queryFn: () => getMediaSearch({ query, type }),
-    queryKey: ['media', query, type],
+    // Keep showing the previous results while a new search is in flight
+    placeholderData: keepPreviousData,
+    queryFn: () =>
+      getMediaSearch({ query: query as string, type: type as MediaType }),
+    // Distinct from the ['media'] list key so list invalidation after
+    // create/update doesn't refetch searches (and vice versa)
+    queryKey: ['media-search', query, type],
+    staleTime: 5 * 60 * 1000,
   })
 }

--- a/packages/web/worker/media/media-apis.rest
+++ b/packages/web/worker/media/media-apis.rest
@@ -7,9 +7,15 @@
 
 ###
 
-# Books
+# Books — Google Books (primary, needs a free API key)
+# Use the `volumeInfo.imageLinks.thumbnail` field to get the cover image
+GET https://www.googleapis.com/books/v1/volumes?q=the%20trading%20game&maxResults=10&printType=books&fields=items(id,volumeInfo(title,authors,imageLinks))&key={{$dotenv MEDIA_GOOGLE_BOOKS_API_KEY}}
+
+###
+
+# Books — Open Library (fallback, no key)
 # Use the `editions.docs[0].cover_i` field to get the cover image
-GET https://openlibrary.org/search.json?q=the%20trading%20game&_spellcheck_count=0&limit=10&fields=key,cover_i,title,subtitle,author_name,editions,name&mode=everything&lang=en&sort=new
+GET https://openlibrary.org/search.json?q=the%20trading%20game&limit=10&fields=key,cover_i,title,author_name,editions&lang=en
 
 ###
 # GET https://covers.openlibrary.org/b/id/15110328-M.jpg?default=https://openlibrary.org/static/images/icons/avatar_book-sm.png

--- a/packages/web/worker/media/mediaSearch.test.ts
+++ b/packages/web/worker/media/mediaSearch.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getGoogleBooksSearch, getOpenLibrarySearch } from './mediaSearch'
+
+const mockFetchJson = (body: unknown, ok = true, status = 200) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve(body),
+    ok,
+    status,
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getGoogleBooksSearch', () => {
+  it('maps volumes to media search items with https covers', async () => {
+    const fetchMock = mockFetchJson({
+      items: [
+        {
+          id: 'abc123',
+          volumeInfo: {
+            authors: ['Frank Herbert'],
+            imageLinks: {
+              smallThumbnail: 'http://books.google.com/small.jpg',
+              thumbnail: 'http://books.google.com/thumb.jpg',
+            },
+            title: 'Dune',
+          },
+        },
+        {
+          id: 'no-title',
+          volumeInfo: {},
+        },
+        {
+          id: 'no-image',
+          volumeInfo: { title: 'Coverless' },
+        },
+      ],
+    })
+
+    const results = await getGoogleBooksSearch('dune', 'test-key')
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0])
+    expect(requestUrl.origin + requestUrl.pathname).toBe(
+      'https://www.googleapis.com/books/v1/volumes',
+    )
+    expect(requestUrl.searchParams.get('q')).toBe('dune')
+    expect(requestUrl.searchParams.get('key')).toBe('test-key')
+
+    expect(results).toHaveLength(2)
+    expect(results[0]).toEqual({
+      id: 'abc123',
+      image: 'https://books.google.com/thumb.jpg',
+      maker: 'Frank Herbert',
+      title: 'Dune',
+      type: 'book',
+    })
+    expect(results[1].image).toContain('placehold.co')
+  })
+
+  it('throws on a non-ok response so the caller can fall back', async () => {
+    mockFetchJson({}, false, 429)
+
+    await expect(getGoogleBooksSearch('dune', 'test-key')).rejects.toThrow(
+      '429',
+    )
+  })
+})
+
+describe('getOpenLibrarySearch', () => {
+  it('prefers edition covers and uses the work key as id', async () => {
+    mockFetchJson({
+      docs: [
+        {
+          author_name: ['Frank Herbert'],
+          cover_i: 111,
+          editions: { docs: [{ cover_i: 222 }] },
+          key: '/works/OL45883W',
+          title: 'Dune',
+        },
+        {
+          key: '/works/OL1W',
+          title: 'Coverless',
+        },
+      ],
+    })
+
+    const results = await getOpenLibrarySearch('dune')
+
+    expect(results[0]).toEqual({
+      id: '/works/OL45883W',
+      image: 'https://covers.openlibrary.org/b/id/222-M.jpg',
+      maker: 'Frank Herbert',
+      title: 'Dune',
+      type: 'book',
+    })
+    expect(results[1].image).toContain('placehold.co')
+  })
+})

--- a/packages/web/worker/media/mediaSearch.ts
+++ b/packages/web/worker/media/mediaSearch.ts
@@ -14,7 +14,7 @@ export type MediaSearchItem = {
 const getTvSearch = async (query: string): Promise<MediaSearchItem[]> => {
   try {
     const response = await fetch(
-      `https://api.tvmaze.com/search/shows?q=${query}`,
+      `https://api.tvmaze.com/search/shows?q=${encodeURIComponent(query)}`,
     )
     const data =
       await response.json<
@@ -45,33 +45,107 @@ const getTvSearch = async (query: string): Promise<MediaSearchItem[]> => {
   }
 }
 
-const getBookSearch = async (query: string): Promise<MediaSearchItem[]> => {
-  try {
-    const response = await fetch(
-      `https://openlibrary.org/search.json?q=${query}&limit=10&fields=key,cover_i,title,subtitle,author_name,editions,name&mode=everything&lang=en&sort=new`,
-    )
-    const data = await response.json<{
-      docs: {
-        cover_i: string
-        editions: { cover_i: string }[]
-        author_name: string[]
-        title: string
-      }[]
-    }>()
-    return data?.docs?.map((item) => {
-      const image = item?.cover_i
-        ? `https://covers.openlibrary.org/b/id/${item?.cover_i}-M.jpg`
-        : `https://placehold.co/600x600?font=Poppins&text=${encodeURI(
-            item.title,
-          )}`
+const bookCoverFallback = (title: string) =>
+  `https://placehold.co/600x600?font=Poppins&text=${encodeURI(title)}`
+
+export const getGoogleBooksSearch = async (
+  query: string,
+  apiKey: string,
+): Promise<MediaSearchItem[]> => {
+  const url = new URL('https://www.googleapis.com/books/v1/volumes')
+  url.searchParams.set('q', query)
+  url.searchParams.set('maxResults', '10')
+  url.searchParams.set('printType', 'books')
+  url.searchParams.set(
+    'fields',
+    'items(id,volumeInfo(title,authors,imageLinks))',
+  )
+  url.searchParams.set('key', apiKey)
+
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Google Books search failed with status ${response.status}`)
+  }
+  const data = await response.json<{
+    items?: {
+      id: string
+      volumeInfo?: {
+        title?: string
+        authors?: string[]
+        imageLinks?: { thumbnail?: string; smallThumbnail?: string }
+      }
+    }[]
+  }>()
+  return (data?.items ?? []).flatMap((item) => {
+    const title = item?.volumeInfo?.title
+    if (!title) {
+      return []
+    }
+    const thumbnail =
+      item.volumeInfo?.imageLinks?.thumbnail ??
+      item.volumeInfo?.imageLinks?.smallThumbnail
+    return {
+      id: item.id,
+      // Google Books serves thumbnails over http by default
+      image:
+        thumbnail?.replace('http://', 'https://') ?? bookCoverFallback(title),
+      maker: item.volumeInfo?.authors?.[0],
+      title,
+      type: 'book' as const,
+    }
+  })
+}
+
+export const getOpenLibrarySearch = async (
+  query: string,
+): Promise<MediaSearchItem[]> => {
+  const response = await fetch(
+    `https://openlibrary.org/search.json?q=${encodeURIComponent(
+      query,
+    )}&limit=10&fields=key,cover_i,title,author_name,editions&lang=en`,
+  )
+  const data = await response.json<{
+    docs: {
+      key: string
+      cover_i?: number
+      editions?: { docs?: { cover_i?: number }[] }
+      author_name?: string[]
+      title: string
+    }[]
+  }>()
+  return (
+    data?.docs?.map((item) => {
+      const coverId = item?.editions?.docs?.[0]?.cover_i ?? item?.cover_i
       return {
-        id: item?.cover_i,
-        image,
+        id: item.key,
+        image: coverId
+          ? `https://covers.openlibrary.org/b/id/${coverId}-M.jpg`
+          : bookCoverFallback(item.title),
         maker: item?.author_name?.[0],
         title: item.title,
-        type: 'book',
+        type: 'book' as const,
       }
-    })
+    }) ?? []
+  )
+}
+
+/**
+ * Book search uses Google Books when an API key is configured (best
+ * relevance + cover images; keyless requests are heavily throttled from
+ * datacenter IPs like Cloudflare Workers, hence the key requirement) and
+ * falls back to Open Library otherwise.
+ */
+const getBookSearch = async (query: string): Promise<MediaSearchItem[]> => {
+  const apiKey = import.meta.env.MEDIA_GOOGLE_BOOKS_API_KEY
+  if (apiKey) {
+    try {
+      return await getGoogleBooksSearch(query, apiKey)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+  try {
+    return await getOpenLibrarySearch(query)
   } catch (err) {
     console.error(err)
     return []
@@ -81,7 +155,7 @@ const getBookSearch = async (query: string): Promise<MediaSearchItem[]> => {
 const getGameSearch = async (query: string): Promise<MediaSearchItem[]> => {
   try {
     const response = await fetch(
-      `https://api.gamebrain.co/v1/games?query=${query}&api-key=${
+      `https://api.gamebrain.co/v1/games?query=${encodeURIComponent(query)}&api-key=${
         import.meta.env.MEDIA_GAMEBRAIN_API_KEY
       }`,
     )
@@ -109,7 +183,7 @@ const getGameSearch = async (query: string): Promise<MediaSearchItem[]> => {
 const getPodcastSearch = async (query: string): Promise<MediaSearchItem[]> => {
   try {
     const response = await fetch(
-      `https://itunes.apple.com/search?term=${query}&entity=podcast&limit=10`,
+      `https://itunes.apple.com/search?term=${encodeURIComponent(query)}&entity=podcast&limit=10`,
     )
     const data = await response.json<{
       results: {


### PR DESCRIPTION
## Summary

Four improvements to the media page:

### 1. Form no longer resets while you type
The add/edit form lost all field state (rating, platform, status…) whenever the name or type changed. Root cause: the catalogue search used `useSuspenseQuery`, so every debounced keystroke changed the query key, suspended the component, and remounted the form — recreating `react-hook-form` state from scratch. The search also shared the `['media']` query key with the media list, so creating/updating an item refetched searches and vice versa.

Now the search uses `useQuery` with `enabled` + `keepPreviousData` under a dedicated `['media-search', query, type]` key, so the form never suspends or remounts. Also fixed along the way: editing an item no longer silently resets its `sort_order` to 0, the status select now reflects the actual form value, and the broken always-rendered `<img>` is replaced by a cover preview with a "Remove image" action.

### 2. Search is its own field
The catalogue search no longer piggybacks on the Name field. There's a dedicated Search input (only shown for types that have a search backend: tv, book, game, podcast); picking a result fills in the name, external id, and cover image, and the selected result is highlighted.

### 3. Better book search API
Open Library results were poor largely because the query sorted by newest (`sort=new`) instead of relevance. Book search now uses the **Google Books volumes API** when `MEDIA_GOOGLE_BOOKS_API_KEY` is set (free key — keyless Google Books requests get zero quota from datacenter IPs like Cloudflare Workers, so a key is required), returning relevance-ranked results with https cover thumbnails. Without a key (or on failure) it falls back to an **improved Open Library query**: relevance-sorted, preferring edition covers, using the work key as the external id. Added unit tests for both mappers and documented the new env var in `.dev.vars.example` / `.env.local.example` / `media-apis.rest`.

### 4. Kanban improvements
- Columns get a card-like surface with a proper header (status colour dot, count badge) and internal scrolling so headers stay visible on long lists
- Clear drop-target feedback (tinted column + border) instead of a grey block behind the cards
- Per-column **+** button opens the form with that column's status preselected
- Empty columns show a dashed drop-zone hint, and no longer crash the page (grouping now always includes every status, ordered by `sort_order`)
- Cards always show the item name, even when a cover image exists
- Columns grow to fill wide screens instead of fixed 268px tracks

## Verification
- `tsc -b` passes
- `pnpm vitest run` — 18 tests pass (3 new for the book search mappers)
- `biome check` clean on all touched files

## Notes
- To use Google Books, create a free key at https://console.cloud.google.com/apis/library/books.googleapis.com and set `MEDIA_GOOGLE_BOOKS_API_KEY` as a Worker secret. Everything still works without it via the Open Library fallback.

https://claude.ai/code/session_017LuYDkwGqjmz7dRw1KNUFx

---
_Generated by [Claude Code](https://claude.ai/code/session_017LuYDkwGqjmz7dRw1KNUFx)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the media form from resetting while you type, adds a dedicated search field, improves book search via Google Books (with Open Library fallback), and polishes the kanban board for clearer, faster workflows.

- New Features
  - Dedicated Search field for `tv`, `book`, `game`, `podcast`; selecting a result fills name, external id, and cover, and highlights the selection.
  - Book search uses Google Books when `MEDIA_GOOGLE_BOOKS_API_KEY` is set; falls back to a better Open Library query. HTTPS cover thumbnails and URL-encoded queries. Example env files document both `MEDIA_GOOGLE_BOOKS_API_KEY` and `MEDIA_GAMEBRAIN_API_KEY`.
  - Kanban: column headers with status dot and count, internal scrolling, clearer drop targets, per-column + (preselects status), empty-state hints, responsive columns, and cards always show the title.

- Bug Fixes
  - Form no longer remounts on keystrokes: switched to `useQuery` with `enabled` and `keepPreviousData` under `['media-search', query, type]`, separate from `['media']`.
  - Preserve `sort_order` on edit; status select reflects the current value; empty columns don’t crash (group by all statuses, ordered by `sort_order`).
  - Dialog remounts when switching between new/edit so form defaults never leak.

<sup>Written for commit aa4b37e63ca947c5eeb72d26668ec9950acc3fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/Otter/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

