### PR TITLE
feat(tui): add otter-tui, a terminal UI for Otter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Otter is a self-hosted bookmark manager and media tracker. This is a **pnpm mono
 | `packages/web-extension` | Cross-browser extension (Chrome + Firefox) — save bookmarks from the browser | Webpack, `TARGET=chrome\|firefox` builds |
 | `packages/raycast-extension` | Raycast commands (search / recent / add / menubar) — auths via the web OAuth provider | Raycast API |
 | `packages/app` | Native macOS/iOS app (Safari web-extension + share sheet) | Xcode / Swift |
+| `packages/tui` | Terminal UI (`otter-tui`) — browse/search/star/add bookmarks from the shell, auths via profile API key | TypeScript, zero runtime deps, Node ≥ 20 |
 | `packages/chrome-extension` | Legacy Chrome extension, superseded by `web-extension` | Webpack |
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "check": "biome check --write",
     "chrome-extension:build": "pnpm --filter=@mrmartineau/otter-chrome-extension run build",
     "preview": "vite preview",
+    "tui:build": "pnpm --filter=@mrmartineau/otter-tui run build",
+    "tui:dev": "pnpm --filter=@mrmartineau/otter-tui run dev",
     "type-check": "tsc --noEmit",
     "web:build": "pnpm --filter=@mrmartineau/otter-web run build",
     "web:dev": "pnpm --filter=@mrmartineau/otter-web run dev"

--- a/packages/tui/.gitignore
+++ b/packages/tui/.gitignore
@@ -1,0 +1,2 @@
+dist
+*.tsbuildinfo

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -1,0 +1,76 @@
+# 🦦 otter-tui
+
+A fast, dependency-free terminal UI for [Otter](https://github.com/mrmartineau/otter) — browse, search, star and save bookmarks without leaving your shell.
+
+```
+ 🦦 Otter  ★ starred · #dev                          1,234 saved · page 2/66
+─────────────────────────────────────────────────────────────────────────────
+ ❯ ★ Building a terminal UI from scratch                              article
+     zander.wtf · #dev · #tui · 3d
+   ★ How Hyperdrive keeps Postgres close to your Worker                  link
+     blog.cloudflare.com · #dev · #cloudflare · 2w
+     A pattern language for self-hosted software                      article
+     example.com · #selfhosted · 1mo
+
+ opened zander.wtf
+ ⏎ open · / search · a add · s star · d delete · t tag · i details · ? help · q quit
+```
+
+No runtime dependencies — just Node.js ≥ 20 and your Otter instance.
+
+## Setup
+
+```sh
+pnpm install
+pnpm --filter=@mrmartineau/otter-tui run build
+node packages/tui/dist/index.js login   # or link it: `pnpm link` → `otter-tui`
+```
+
+`login` asks for your Otter URL and API key (Otter → Settings → API key), verifies them against `/api/me`, and writes `~/.config/otter/config.json`. The `OTTER_BASE_URL` and `OTTER_API_KEY` environment variables override the file, so you can also skip `login` entirely.
+
+During development you can run the TypeScript sources directly (Node ≥ 22.18):
+
+```sh
+pnpm --filter=@mrmartineau/otter-tui run dev
+```
+
+## Usage
+
+```sh
+otter-tui                   # browse your bookmarks
+otter-tui add <url> [tag …] # quick-save from the command line (Otter scrapes the page)
+otter-tui login             # (re)configure credentials
+```
+
+### Keybindings
+
+| Key | Action |
+| --- | --- |
+| `↑`/`↓` or `j`/`k` | move selection |
+| `←`/`→` or `h`/`l` | previous / next page |
+| `⏎` or `o` | open in browser (registers a click) |
+| `i` | bookmark details |
+| `/` | search (title, URL, description, note, tag) |
+| `a` | add a bookmark — paste a URL, Otter scrapes the rest |
+| `s` | star / unstar |
+| `d` | delete (asks for confirmation) |
+| `f` | toggle the starred filter |
+| `t` | pick a tag to filter by |
+| `c` | cycle the type filter (article, link, video, …) |
+| `x` | clear search + all filters |
+| `r` | refresh |
+| `?` | help |
+| `q` / `ctrl-c` | quit |
+
+## How it talks to Otter
+
+The TUI authenticates with your profile API key as a `Bearer` token and uses the same REST API as the other Otter clients: `GET /api/bookmarks`, `GET /api/search`, `GET /api/tags`, `POST /api/new` (with server-side scraping), `PATCH`/`DELETE /api/bookmarks/:id` and `POST /api/bookmarks/:id/click`.
+
+## Development
+
+```sh
+pnpm --filter=@mrmartineau/otter-tui run build   # tsc → dist/
+pnpm --filter=@mrmartineau/otter-tui exec vitest run
+```
+
+The renderer (`src/ui.ts`) is a pure function of app state, and the input parser, text measurement and formatting helpers are pure modules with unit tests.

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -23,10 +23,10 @@ No runtime dependencies — just Node.js ≥ 20 and your Otter instance.
 ```sh
 pnpm install
 pnpm --filter=@mrmartineau/otter-tui run build
-node packages/tui/dist/index.js login   # or link it: `pnpm link` → `otter-tui`
+node packages/tui/dist/index.js login   # or link it: `pnpm link --global` → `otter-tui`
 ```
 
-`login` asks for your Otter URL and API key (Otter → Settings → API key), verifies them against `/api/me`, and writes `~/.config/otter/config.json`. The `OTTER_BASE_URL` and `OTTER_API_KEY` environment variables override the file, so you can also skip `login` entirely.
+`login` asks for your Otter URL and API key (Otter → Settings → API key), verifies them against `/api/me`, and writes `$XDG_CONFIG_HOME/otter/config.json` (defaulting to `~/.config/otter/config.json`). The `OTTER_BASE_URL` and `OTTER_API_KEY` environment variables override the file, so you can also skip `login` entirely.
 
 During development you can run the TypeScript sources directly (Node ≥ 22.18):
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -4,7 +4,7 @@
   },
   "description": "Terminal UI for Otter — browse, search and save bookmarks without leaving your shell",
   "devDependencies": {
-    "@types/node": "^22.15.0",
+    "@types/node": "^20.19.0",
     "typescript": "^5.9.3",
     "vitest": "catalog:"
   },

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,0 +1,27 @@
+{
+  "bin": {
+    "otter-tui": "dist/index.js"
+  },
+  "description": "Terminal UI for Otter — browse, search and save bookmarks without leaving your shell",
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "typescript": "^5.9.3",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "name": "@mrmartineau/otter-tui",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "node src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "type": "module",
+  "version": "0.0.0"
+}

--- a/packages/tui/src/ansi.test.ts
+++ b/packages/tui/src/ansi.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { padToWidth, stringWidth, stripAnsi, truncate } from './ansi.ts'
+import {
+  padToWidth,
+  sanitize,
+  stringWidth,
+  stripAnsi,
+  truncate,
+} from './ansi.ts'
 
 describe('stripAnsi', () => {
   it('removes SGR sequences', () => {
@@ -24,6 +30,21 @@ describe('stringWidth', () => {
   it('counts emoji and CJK as 2 columns', () => {
     expect(stringWidth('🦦')).toBe(2)
     expect(stringWidth('日本')).toBe(4)
+  })
+
+  it('treats emoji skin-tone modifiers as zero width', () => {
+    expect(stringWidth('👍🏽')).toBe(2)
+  })
+})
+
+describe('sanitize', () => {
+  it('strips escape sequences and control characters', () => {
+    expect(sanitize('a\x1b[31mred\x1b[0mb')).toBe('a[31mred[0mb')
+    expect(sanitize('x\x07\x00y')).toBe('xy')
+  })
+
+  it('keeps tab, newline and carriage return', () => {
+    expect(sanitize('a\tb\nc\rd')).toBe('a\tb\nc\rd')
   })
 })
 

--- a/packages/tui/src/ansi.test.ts
+++ b/packages/tui/src/ansi.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { padToWidth, stringWidth, stripAnsi, truncate } from './ansi.ts'
+
+describe('stripAnsi', () => {
+  it('removes SGR sequences', () => {
+    expect(stripAnsi('\x1b[1mhello\x1b[22m')).toBe('hello')
+    expect(stripAnsi('\x1b[38;5;208motter\x1b[39m')).toBe('otter')
+  })
+
+  it('leaves plain text alone', () => {
+    expect(stripAnsi('plain')).toBe('plain')
+  })
+})
+
+describe('stringWidth', () => {
+  it('counts ascii as 1 column', () => {
+    expect(stringWidth('otter')).toBe(5)
+  })
+
+  it('ignores ansi codes', () => {
+    expect(stringWidth('\x1b[1motter\x1b[22m')).toBe(5)
+  })
+
+  it('counts emoji and CJK as 2 columns', () => {
+    expect(stringWidth('🦦')).toBe(2)
+    expect(stringWidth('日本')).toBe(4)
+  })
+})
+
+describe('truncate', () => {
+  it('returns short strings untouched', () => {
+    expect(truncate('otter', 10)).toBe('otter')
+  })
+
+  it('cuts long strings with an ellipsis', () => {
+    expect(truncate('otter bookmarks', 8)).toBe('otter b…')
+  })
+
+  it('handles zero width', () => {
+    expect(truncate('otter', 0)).toBe('')
+  })
+})
+
+describe('padToWidth', () => {
+  it('pads to the requested display width', () => {
+    expect(padToWidth('ab', 5)).toBe('ab   ')
+  })
+
+  it('accounts for ansi codes when padding', () => {
+    expect(padToWidth('\x1b[1mab\x1b[22m', 4)).toBe('\x1b[1mab\x1b[22m  ')
+  })
+
+  it('never pads negatively', () => {
+    expect(padToWidth('abcdef', 3)).toBe('abcdef')
+  })
+})

--- a/packages/tui/src/ansi.ts
+++ b/packages/tui/src/ansi.ts
@@ -1,0 +1,127 @@
+/**
+ * Minimal ANSI/terminal helpers — no dependencies.
+ *
+ * Style helpers wrap text in SGR escape codes. Text measurement helpers
+ * (stringWidth/truncate/padToWidth) expect *plain* text, so always truncate
+ * first and style afterwards.
+ */
+
+const CSI = '\x1b['
+
+export const cursor = {
+  hide: `${CSI}?25l`,
+  home: `${CSI}H`,
+  show: `${CSI}?25h`,
+  to: (row: number, col: number) => `${CSI}${row};${col}H`,
+}
+
+export const screen = {
+  alt: `${CSI}?1049h`,
+  clear: `${CSI}2J`,
+  clearDown: `${CSI}J`,
+  clearLine: `${CSI}K`,
+  main: `${CSI}?1049l`,
+}
+
+const sgr = (open: number, close: number) => (text: string) =>
+  `${CSI}${open}m${text}${CSI}${close}m`
+
+export const bold = sgr(1, 22)
+export const dim = sgr(2, 22)
+export const italic = sgr(3, 23)
+export const underline = sgr(4, 24)
+export const reverse = sgr(7, 27)
+
+export const fg = (color: number) => (text: string) =>
+  `${CSI}38;5;${color}m${text}${CSI}39m`
+
+export const bg = (color: number) => (text: string) =>
+  `${CSI}48;5;${color}m${text}${CSI}49m`
+
+// Otter's terminal palette (xterm-256 indexes)
+export const palette = {
+  accent: 208, // otter orange
+  border: 240,
+  danger: 203,
+  muted: 245,
+  star: 220,
+  tag: 114,
+  url: 75,
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences is the point
+const ansiPattern = /\x1b\[[0-9;?]*[A-Za-z]/g
+
+export const stripAnsi = (text: string) => text.replace(ansiPattern, '')
+
+const isZeroWidth = (codePoint: number) =>
+  (codePoint >= 0x300 && codePoint <= 0x36f) || // combining marks
+  codePoint === 0x200d || // zero-width joiner
+  (codePoint >= 0xfe00 && codePoint <= 0xfe0f) // variation selectors
+
+const isWide = (codePoint: number) =>
+  codePoint >= 0x1100 &&
+  (codePoint <= 0x115f || // Hangul Jamo
+    codePoint === 0x2329 ||
+    codePoint === 0x232a ||
+    (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) || // CJK
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) || // Hangul syllables
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) || // CJK compat ideographs
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) || // CJK compat forms
+    (codePoint >= 0xff00 && codePoint <= 0xff60) || // fullwidth forms
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1f300 && codePoint <= 0x1faff) || // emoji
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd))
+
+export const charWidth = (codePoint: number) => {
+  if (isZeroWidth(codePoint)) {
+    return 0
+  }
+
+  return isWide(codePoint) ? 2 : 1
+}
+
+/** Display width of a string (ANSI codes stripped, wide chars counted as 2). */
+export const stringWidth = (text: string) => {
+  let width = 0
+
+  for (const char of stripAnsi(text)) {
+    width += charWidth(char.codePointAt(0) ?? 0)
+  }
+
+  return width
+}
+
+/** Truncate *plain* text to a display width, adding an ellipsis when cut. */
+export const truncate = (text: string, maxWidth: number) => {
+  if (maxWidth <= 0) {
+    return ''
+  }
+
+  if (stringWidth(text) <= maxWidth) {
+    return text
+  }
+
+  let width = 0
+  let result = ''
+
+  for (const char of text) {
+    const nextWidth = width + charWidth(char.codePointAt(0) ?? 0)
+
+    if (nextWidth > maxWidth - 1) {
+      break
+    }
+
+    result += char
+    width = nextWidth
+  }
+
+  return `${result}…`
+}
+
+/** Pad (styled or plain) text with trailing spaces up to a display width. */
+export const padToWidth = (text: string, width: number) => {
+  const padding = width - stringWidth(text)
+
+  return padding > 0 ? text + ' '.repeat(padding) : text
+}

--- a/packages/tui/src/ansi.ts
+++ b/packages/tui/src/ansi.ts
@@ -54,9 +54,19 @@ const ansiPattern = /\x1b\[[0-9;?]*[A-Za-z]/g
 
 export const stripAnsi = (text: string) => text.replace(ansiPattern, '')
 
+// C0/C1 control characters minus TAB, LF and CR — anything that could move the
+// cursor, change colours or otherwise hijack the terminal. ESC (0x1b) is in
+// the 0x0e–0x1f range, so escape sequences in untrusted text get neutralised.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping terminal control chars from untrusted API text is the point
+const controlPattern = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g
+
+/** Strip terminal control characters from untrusted text (escape injection). */
+export const sanitize = (text: string) => text.replace(controlPattern, '')
+
 const isZeroWidth = (codePoint: number) =>
   (codePoint >= 0x300 && codePoint <= 0x36f) || // combining marks
   codePoint === 0x200d || // zero-width joiner
+  (codePoint >= 0x1f3fb && codePoint <= 0x1f3ff) || // emoji skin-tone modifiers
   (codePoint >= 0xfe00 && codePoint <= 0xfe0f) // variation selectors
 
 const isWide = (codePoint: number) =>

--- a/packages/tui/src/api.ts
+++ b/packages/tui/src/api.ts
@@ -131,6 +131,8 @@ export class OtterClient {
         limit: params.limit,
         offset: params.offset,
         q: searchTerm,
+        star: params.star,
+        tag: params.tag,
         type: params.type,
       },
     })

--- a/packages/tui/src/api.ts
+++ b/packages/tui/src/api.ts
@@ -1,0 +1,165 @@
+import type { OtterConfig } from './config.ts'
+
+/** Mirrors the web worker's BaseBookmark row shape. */
+export interface Bookmark {
+  click_count: number
+  created_at: string
+  description: string | null
+  id: string
+  image: string | null
+  modified_at: string
+  note: string | null
+  public: boolean
+  star: boolean
+  status: 'active' | 'inactive'
+  tags: string[] | null
+  title: string | null
+  type: string | null
+  url: string | null
+}
+
+export interface TagCount {
+  count: number
+  tag: string
+}
+
+export interface ListResponse<T> {
+  count: number
+  data: T[]
+  limit: number
+  offset: number
+}
+
+export interface Profile {
+  id: string
+  username: string | null
+}
+
+export interface ListParams {
+  limit?: number
+  offset?: number
+  star?: boolean
+  tag?: string
+  type?: string
+}
+
+type Query = Record<string, string | number | boolean | undefined>
+
+interface RequestOptions {
+  body?: unknown
+  method?: string
+  query?: Query
+}
+
+/**
+ * Thin client for the Otter worker API, authenticating with the profile
+ * API key as a Bearer token (see worker/context.ts).
+ */
+export class OtterClient {
+  apiKey: string
+  baseUrl: string
+
+  constructor(config: OtterConfig) {
+    this.apiKey = config.apiKey
+    this.baseUrl = config.baseUrl
+  }
+
+  async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const url = new URL(`${this.baseUrl}/api${path}`)
+
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      if (value !== undefined && value !== '') {
+        url.searchParams.set(key, String(value))
+      }
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+    }
+
+    if (options.body !== undefined) {
+      headers['Content-Type'] = 'application/json'
+    }
+
+    let response: Response
+
+    try {
+      response = await fetch(url, {
+        body:
+          options.body === undefined ? undefined : JSON.stringify(options.body),
+        headers,
+        method: options.method ?? 'GET',
+      })
+    } catch (error) {
+      throw new Error(
+        `Could not reach ${url.host} (${error instanceof Error ? error.message : String(error)})`,
+      )
+    }
+
+    const text = await response.text()
+    let parsed: unknown = null
+
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      // non-JSON error body — handled below
+    }
+
+    if (!response.ok) {
+      const body = (parsed ?? {}) as { error?: string; reason?: string }
+      throw new Error(
+        body.reason || body.error || `HTTP ${response.status} from ${path}`,
+      )
+    }
+
+    return parsed as T
+  }
+
+  me() {
+    return this.request<Profile>('/me')
+  }
+
+  listBookmarks(params: ListParams) {
+    return this.request<ListResponse<Bookmark>>('/bookmarks', {
+      query: { ...params },
+    })
+  }
+
+  searchBookmarks(searchTerm: string, params: ListParams) {
+    return this.request<ListResponse<Bookmark>>('/search', {
+      query: {
+        limit: params.limit,
+        offset: params.offset,
+        q: searchTerm,
+        type: params.type,
+      },
+    })
+  }
+
+  tags() {
+    return this.request<TagCount[]>('/tags')
+  }
+
+  /** Adds a bookmark; the worker scrapes title/description/type from the URL. */
+  addBookmark(url: string, tags: string[] = []) {
+    return this.request<Bookmark[]>('/new', {
+      body: [{ scrape: true, tags, url }],
+      method: 'POST',
+    })
+  }
+
+  updateBookmark(id: string, patch: Partial<Bookmark>) {
+    return this.request<Bookmark>(`/bookmarks/${id}`, {
+      body: patch,
+      method: 'PATCH',
+    })
+  }
+
+  deleteBookmark(id: string) {
+    return this.request<unknown>(`/bookmarks/${id}`, { method: 'DELETE' })
+  }
+
+  registerClick(id: string) {
+    return this.request<unknown>(`/bookmarks/${id}/click`, { method: 'POST' })
+  }
+}

--- a/packages/tui/src/app.ts
+++ b/packages/tui/src/app.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
-import { cursor, screen } from './ansi.ts'
-import type { ListParams, OtterClient } from './api.ts'
+import { cursor, sanitize, screen } from './ansi.ts'
+import type { Bookmark, ListParams, OtterClient } from './api.ts'
 import { domain } from './format.ts'
 import type { Key } from './keys.ts'
 import { parseInput } from './keys.ts'
@@ -9,11 +9,14 @@ import { initialState, TYPE_CYCLE } from './state.ts'
 import { renderFrame, tagMatches, visibleItems } from './ui.ts'
 
 const openInBrowser = (url: string) => {
+  // On Windows, `cmd /c start` would route the URL through the cmd parser,
+  // where `&`/`|`/`^` (common in query strings) get interpreted. rundll32
+  // takes the URL as a single argv with no shell, so nothing is reinterpreted.
   const [command, args] =
     process.platform === 'darwin'
       ? ['open', [url]]
       : process.platform === 'win32'
-        ? ['cmd', ['/c', 'start', '', url]]
+        ? ['rundll32', ['url.dll,FileProtocolHandler', url]]
         : ['xdg-open', [url]]
 
   spawn(command, args as string[], { detached: true, stdio: 'ignore' })
@@ -23,12 +26,32 @@ const openInBrowser = (url: string) => {
     .unref()
 }
 
+const clean = (value: string | null) =>
+  value === null ? null : sanitize(value)
+
+/**
+ * Strip terminal control characters from bookmark text before it ever reaches
+ * the renderer or a status line — API content is untrusted and could otherwise
+ * smuggle escape sequences into the terminal.
+ */
+const sanitizeBookmark = (bookmark: Bookmark): Bookmark => ({
+  ...bookmark,
+  description: clean(bookmark.description),
+  note: clean(bookmark.note),
+  tags: bookmark.tags?.map((tag) => sanitize(tag)) ?? null,
+  title: clean(bookmark.title),
+  type: clean(bookmark.type),
+  url: clean(bookmark.url),
+})
+
 export class App {
   client: OtterClient
   state: AppState
   private requestSeq = 0
   private input = process.stdin
   private output = process.stdout
+  /** Carries an incomplete escape sequence between stdin reads. */
+  private inputBuffer = ''
 
   constructor(client: OtterClient) {
     this.client = client
@@ -42,7 +65,10 @@ export class App {
     this.input.resume()
     this.input.setEncoding('utf8')
     this.input.on('data', (chunk) => {
-      for (const key of parseInput(String(chunk))) {
+      const { keys, rest } = parseInput(this.inputBuffer + String(chunk))
+      this.inputBuffer = rest
+
+      for (const key of keys) {
         this.handleKey(key)
       }
     })
@@ -76,8 +102,7 @@ export class App {
 
   private async loadProfile() {
     try {
-      const profile = await this.client.me()
-      this.state.username = profile.username ?? ''
+      await this.client.me()
     } catch (error) {
       this.setStatus(
         `auth check failed: ${error instanceof Error ? error.message : error}`,
@@ -110,7 +135,7 @@ export class App {
       }
 
       state.count = response.count
-      state.items = response.data
+      state.items = response.data.map(sanitizeBookmark)
       state.offset = offset
       state.selected = Math.max(
         0,
@@ -322,7 +347,7 @@ export class App {
     } else if (key.name === 'up') {
       state.tagCursor = Math.max(state.tagCursor - 1, 0)
     } else if (key.name === 'backspace') {
-      state.tagInput = state.tagInput.slice(0, -1)
+      state.tagInput = Array.from(state.tagInput).slice(0, -1).join('')
       state.tagCursor = 0
     } else if (key.name === 'char' && key.char) {
       state.tagInput += key.char
@@ -367,7 +392,10 @@ export class App {
     this.render()
 
     try {
-      state.tags = await this.client.tags()
+      state.tags = (await this.client.tags()).map((entry) => ({
+        ...entry,
+        tag: sanitize(entry.tag),
+      }))
     } catch (error) {
       state.mode = 'list'
       this.setStatus(
@@ -408,6 +436,12 @@ export class App {
     try {
       await this.client.updateBookmark(bookmark.id, { star: bookmark.star })
       this.setStatus(bookmark.star ? '★ starred' : 'unstarred')
+
+      // The item no longer matches a starred-only view — drop it by refetching.
+      if (!bookmark.star && this.state.starOnly) {
+        await this.fetchPage(this.state.offset)
+        return
+      }
     } catch (error) {
       bookmark.star = !bookmark.star
       this.setStatus(

--- a/packages/tui/src/app.ts
+++ b/packages/tui/src/app.ts
@@ -1,0 +1,482 @@
+import { spawn } from 'node:child_process'
+import { cursor, screen } from './ansi.ts'
+import type { ListParams, OtterClient } from './api.ts'
+import { domain } from './format.ts'
+import type { Key } from './keys.ts'
+import { parseInput } from './keys.ts'
+import type { AppState } from './state.ts'
+import { initialState, TYPE_CYCLE } from './state.ts'
+import { renderFrame, tagMatches, visibleItems } from './ui.ts'
+
+const openInBrowser = (url: string) => {
+  const [command, args] =
+    process.platform === 'darwin'
+      ? ['open', [url]]
+      : process.platform === 'win32'
+        ? ['cmd', ['/c', 'start', '', url]]
+        : ['xdg-open', [url]]
+
+  spawn(command, args as string[], { detached: true, stdio: 'ignore' })
+    .on('error', () => {
+      // opener missing — the URL stays visible in the UI either way
+    })
+    .unref()
+}
+
+export class App {
+  client: OtterClient
+  state: AppState
+  private requestSeq = 0
+  private input = process.stdin
+  private output = process.stdout
+
+  constructor(client: OtterClient) {
+    this.client = client
+    this.state = initialState()
+  }
+
+  start() {
+    this.state.pageSize = visibleItems(this.output.rows || 24)
+    this.output.write(screen.alt + cursor.hide + screen.clear)
+    this.input.setRawMode(true)
+    this.input.resume()
+    this.input.setEncoding('utf8')
+    this.input.on('data', (chunk) => {
+      for (const key of parseInput(String(chunk))) {
+        this.handleKey(key)
+      }
+    })
+    this.output.on('resize', () => this.handleResize())
+    void this.loadProfile()
+    void this.fetchPage(0)
+    this.render()
+  }
+
+  quit(): never {
+    this.output.write(screen.main + cursor.show)
+    this.input.setRawMode(false)
+    this.input.pause()
+    process.exit(0)
+  }
+
+  render() {
+    this.output.write(
+      renderFrame(
+        this.state,
+        this.output.columns || 80,
+        this.output.rows || 24,
+      ),
+    )
+  }
+
+  private setStatus(status: string, kind: 'error' | 'info' = 'info') {
+    this.state.status = status
+    this.state.statusKind = kind
+  }
+
+  private async loadProfile() {
+    try {
+      const profile = await this.client.me()
+      this.state.username = profile.username ?? ''
+    } catch (error) {
+      this.setStatus(
+        `auth check failed: ${error instanceof Error ? error.message : error}`,
+        'error',
+      )
+      this.render()
+    }
+  }
+
+  async fetchPage(offset: number) {
+    const seq = ++this.requestSeq
+    const { state } = this
+    state.loading = true
+    this.render()
+
+    try {
+      const params: ListParams = {
+        limit: state.pageSize,
+        offset,
+        star: state.starOnly || undefined,
+        tag: state.tag ?? undefined,
+        type: state.typeFilter ?? undefined,
+      }
+      const response = state.query
+        ? await this.client.searchBookmarks(state.query, params)
+        : await this.client.listBookmarks(params)
+
+      if (seq !== this.requestSeq) {
+        return
+      }
+
+      state.count = response.count
+      state.items = response.data
+      state.offset = offset
+      state.selected = Math.max(
+        0,
+        Math.min(state.selected, response.data.length - 1),
+      )
+      state.loading = false
+    } catch (error) {
+      if (seq !== this.requestSeq) {
+        return
+      }
+
+      state.loading = false
+      this.setStatus(
+        error instanceof Error ? error.message : String(error),
+        'error',
+      )
+    }
+
+    this.render()
+  }
+
+  private handleResize() {
+    const pageSize = visibleItems(this.output.rows || 24)
+
+    if (pageSize !== this.state.pageSize) {
+      this.state.pageSize = pageSize
+      const offset = Math.floor(this.state.offset / pageSize) * pageSize
+      void this.fetchPage(offset)
+    }
+
+    this.render()
+  }
+
+  private handleKey(key: Key) {
+    if (key.ctrl && key.name === 'c') {
+      this.quit()
+    }
+
+    switch (this.state.mode) {
+      case 'list':
+        this.handleListKey(key)
+        break
+      case 'search':
+      case 'add':
+        this.handleInputKey(key)
+        break
+      case 'confirm-delete':
+        this.handleConfirmKey(key)
+        break
+      case 'detail':
+        this.handleDetailKey(key)
+        break
+      case 'tags':
+        this.handleTagsKey(key)
+        break
+      case 'help':
+        this.state.mode = 'list'
+        this.render()
+        break
+    }
+  }
+
+  private handleListKey(key: Key) {
+    const char = key.name === 'char' ? key.char : undefined
+    const { state } = this
+
+    if (key.name === 'down' || char === 'j') {
+      state.status = ''
+      state.selected = Math.min(state.selected + 1, state.items.length - 1)
+    } else if (key.name === 'up' || char === 'k') {
+      state.status = ''
+      state.selected = Math.max(state.selected - 1, 0)
+    } else if (key.name === 'home' || char === 'g') {
+      state.selected = 0
+    } else if (key.name === 'end' || char === 'G') {
+      state.selected = Math.max(0, state.items.length - 1)
+    } else if (
+      key.name === 'right' ||
+      key.name === 'pagedown' ||
+      char === 'l'
+    ) {
+      this.nextPage()
+      return
+    } else if (key.name === 'left' || key.name === 'pageup' || char === 'h') {
+      this.previousPage()
+      return
+    } else if (key.name === 'enter' || char === 'o') {
+      this.openSelected()
+    } else if (char === '/') {
+      state.mode = 'search'
+      state.input = state.query
+    } else if (char === 'a') {
+      state.mode = 'add'
+      state.input = ''
+    } else if (char === 's') {
+      void this.toggleStar()
+      return
+    } else if (char === 'd' && state.items.length) {
+      state.mode = 'confirm-delete'
+    } else if (char === 'f') {
+      state.starOnly = !state.starOnly
+      void this.fetchPage(0)
+      return
+    } else if (char === 'c') {
+      this.cycleTypeFilter()
+      return
+    } else if (char === 't') {
+      void this.openTagPicker()
+      return
+    } else if (char === 'x') {
+      state.query = ''
+      state.starOnly = false
+      state.tag = null
+      state.typeFilter = null
+      void this.fetchPage(0)
+      return
+    } else if (char === 'r') {
+      void this.fetchPage(state.offset)
+      return
+    } else if (char === 'i' && state.items.length) {
+      state.mode = 'detail'
+    } else if (char === '?') {
+      state.mode = 'help'
+    } else if (char === 'q') {
+      this.quit()
+    }
+
+    this.render()
+  }
+
+  private handleInputKey(key: Key) {
+    const { state } = this
+
+    if (key.name === 'escape') {
+      state.mode = 'list'
+      state.input = ''
+    } else if (key.name === 'enter') {
+      if (state.mode === 'search') {
+        state.query = state.input.trim()
+        state.mode = 'list'
+        void this.fetchPage(0)
+        return
+      }
+
+      void this.submitAdd()
+      return
+    } else if (key.name === 'backspace') {
+      state.input = Array.from(state.input).slice(0, -1).join('')
+    } else if (key.ctrl && key.name === 'u') {
+      state.input = ''
+    } else if (key.name === 'char' && key.char) {
+      state.input += key.char
+    }
+
+    this.render()
+  }
+
+  private handleConfirmKey(key: Key) {
+    const confirmed =
+      key.name === 'char' && (key.char === 'y' || key.char === 'Y')
+    this.state.mode = 'list'
+
+    if (confirmed) {
+      void this.deleteSelected()
+      return
+    }
+
+    this.render()
+  }
+
+  private handleDetailKey(key: Key) {
+    const char = key.name === 'char' ? key.char : undefined
+    const { state } = this
+
+    if (key.name === 'escape' || char === 'i' || char === 'q') {
+      state.mode = 'list'
+    } else if (key.name === 'down' || char === 'j') {
+      state.selected = Math.min(state.selected + 1, state.items.length - 1)
+    } else if (key.name === 'up' || char === 'k') {
+      state.selected = Math.max(state.selected - 1, 0)
+    } else if (key.name === 'enter' || char === 'o') {
+      this.openSelected()
+    } else if (char === 's') {
+      void this.toggleStar()
+      return
+    }
+
+    this.render()
+  }
+
+  private handleTagsKey(key: Key) {
+    const { state } = this
+
+    if (key.name === 'escape') {
+      state.mode = 'list'
+    } else if (key.name === 'enter') {
+      const matches = tagMatches(state.tags, state.tagInput)
+      const chosen = matches[state.tagCursor]
+      state.mode = 'list'
+
+      if (chosen) {
+        state.tag = chosen.tag
+        void this.fetchPage(0)
+        return
+      }
+    } else if (key.name === 'down') {
+      const matches = tagMatches(state.tags, state.tagInput)
+      state.tagCursor = Math.min(state.tagCursor + 1, matches.length - 1)
+    } else if (key.name === 'up') {
+      state.tagCursor = Math.max(state.tagCursor - 1, 0)
+    } else if (key.name === 'backspace') {
+      state.tagInput = state.tagInput.slice(0, -1)
+      state.tagCursor = 0
+    } else if (key.name === 'char' && key.char) {
+      state.tagInput += key.char
+      state.tagCursor = 0
+    }
+
+    this.render()
+  }
+
+  private nextPage() {
+    const { state } = this
+
+    if (state.offset + state.pageSize < state.count) {
+      state.selected = 0
+      void this.fetchPage(state.offset + state.pageSize)
+    }
+  }
+
+  private previousPage() {
+    const { state } = this
+
+    if (state.offset > 0) {
+      state.selected = 0
+      void this.fetchPage(Math.max(0, state.offset - state.pageSize))
+    }
+  }
+
+  private cycleTypeFilter() {
+    const { state } = this
+    const index = TYPE_CYCLE.indexOf(
+      state.typeFilter as (typeof TYPE_CYCLE)[number],
+    )
+    state.typeFilter = TYPE_CYCLE[(index + 1) % TYPE_CYCLE.length] ?? null
+    void this.fetchPage(0)
+  }
+
+  private async openTagPicker() {
+    const { state } = this
+    state.mode = 'tags'
+    state.tagCursor = 0
+    state.tagInput = ''
+    this.render()
+
+    try {
+      state.tags = await this.client.tags()
+    } catch (error) {
+      state.mode = 'list'
+      this.setStatus(
+        error instanceof Error ? error.message : String(error),
+        'error',
+      )
+    }
+
+    this.render()
+  }
+
+  private openSelected() {
+    const bookmark = this.state.items[this.state.selected]
+
+    if (!bookmark?.url) {
+      this.setStatus('selected bookmark has no URL', 'error')
+      return
+    }
+
+    openInBrowser(bookmark.url)
+    bookmark.click_count += 1
+    this.client.registerClick(bookmark.id).catch(() => {
+      // click tracking is best-effort
+    })
+    this.setStatus(`opened ${domain(bookmark.url) || bookmark.url}`)
+  }
+
+  private async toggleStar() {
+    const bookmark = this.state.items[this.state.selected]
+
+    if (!bookmark) {
+      return
+    }
+
+    bookmark.star = !bookmark.star
+    this.render()
+
+    try {
+      await this.client.updateBookmark(bookmark.id, { star: bookmark.star })
+      this.setStatus(bookmark.star ? '★ starred' : 'unstarred')
+    } catch (error) {
+      bookmark.star = !bookmark.star
+      this.setStatus(
+        error instanceof Error ? error.message : String(error),
+        'error',
+      )
+    }
+
+    this.render()
+  }
+
+  private async deleteSelected() {
+    const { state } = this
+    const bookmark = state.items[state.selected]
+
+    if (!bookmark) {
+      return
+    }
+
+    this.setStatus('deleting…')
+    this.render()
+
+    try {
+      await this.client.deleteBookmark(bookmark.id)
+      this.setStatus(
+        `deleted “${bookmark.title || bookmark.url || bookmark.id}”`,
+      )
+      const offset =
+        state.items.length === 1 && state.offset > 0
+          ? Math.max(0, state.offset - state.pageSize)
+          : state.offset
+      await this.fetchPage(offset)
+    } catch (error) {
+      this.setStatus(
+        error instanceof Error ? error.message : String(error),
+        'error',
+      )
+      this.render()
+    }
+  }
+
+  private async submitAdd() {
+    const { state } = this
+    const raw = state.input.trim()
+    state.mode = 'list'
+    state.input = ''
+
+    if (!raw) {
+      this.render()
+      return
+    }
+
+    const url = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`
+    this.setStatus(`saving ${url}…`)
+    state.loading = true
+    this.render()
+
+    try {
+      const [saved] = await this.client.addBookmark(url)
+      state.loading = false
+      this.setStatus(`saved “${saved?.title || url}”`)
+      await this.fetchPage(0)
+    } catch (error) {
+      state.loading = false
+      this.setStatus(
+        error instanceof Error ? error.message : String(error),
+        'error',
+      )
+      this.render()
+    }
+  }
+}

--- a/packages/tui/src/config.ts
+++ b/packages/tui/src/config.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -31,14 +31,16 @@ export const loadConfig = (): OtterConfig | null => {
     // missing or invalid file — fall through to env-only
   }
 
-  const baseUrl = process.env.OTTER_BASE_URL || file.baseUrl
-  const apiKey = process.env.OTTER_API_KEY || file.apiKey
+  // Trim before the completeness check so whitespace-only values (e.g. a
+  // stray space in an env var) are treated as missing rather than valid.
+  const baseUrl = (process.env.OTTER_BASE_URL || file.baseUrl)?.trim()
+  const apiKey = (process.env.OTTER_API_KEY || file.apiKey)?.trim()
 
   if (!baseUrl || !apiKey) {
     return null
   }
 
-  return { apiKey: apiKey.trim(), baseUrl: normaliseBaseUrl(baseUrl) }
+  return { apiKey, baseUrl: normaliseBaseUrl(baseUrl) }
 }
 
 export const saveConfig = (config: OtterConfig) => {
@@ -56,6 +58,9 @@ export const saveConfig = (config: OtterConfig) => {
     )}\n`,
     { mode: 0o600 },
   )
+  // `mode` only applies when writeFileSync creates the file; an existing
+  // config keeps its old (possibly looser) permissions, so tighten it here.
+  chmodSync(path, 0o600)
 
   return path
 }

--- a/packages/tui/src/config.ts
+++ b/packages/tui/src/config.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+export interface OtterConfig {
+  apiKey: string
+  baseUrl: string
+}
+
+export const configPath = () =>
+  join(
+    process.env.XDG_CONFIG_HOME || join(homedir(), '.config'),
+    'otter',
+    'config.json',
+  )
+
+const normaliseBaseUrl = (baseUrl: string) => baseUrl.trim().replace(/\/+$/, '')
+
+/**
+ * Resolve config from `OTTER_BASE_URL` / `OTTER_API_KEY` env vars, falling
+ * back to ~/.config/otter/config.json. Returns null when incomplete.
+ */
+export const loadConfig = (): OtterConfig | null => {
+  let file: Partial<OtterConfig> = {}
+
+  try {
+    file = JSON.parse(readFileSync(configPath(), 'utf8')) as
+      | Partial<OtterConfig>
+      | Record<string, never>
+  } catch {
+    // missing or invalid file — fall through to env-only
+  }
+
+  const baseUrl = process.env.OTTER_BASE_URL || file.baseUrl
+  const apiKey = process.env.OTTER_API_KEY || file.apiKey
+
+  if (!baseUrl || !apiKey) {
+    return null
+  }
+
+  return { apiKey: apiKey.trim(), baseUrl: normaliseBaseUrl(baseUrl) }
+}
+
+export const saveConfig = (config: OtterConfig) => {
+  const path = configPath()
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        apiKey: config.apiKey.trim(),
+        baseUrl: normaliseBaseUrl(config.baseUrl),
+      },
+      null,
+      2,
+    )}\n`,
+    { mode: 0o600 },
+  )
+
+  return path
+}

--- a/packages/tui/src/format.test.ts
+++ b/packages/tui/src/format.test.ts
@@ -53,6 +53,11 @@ describe('wrapText', () => {
     expect(wrapText('abcdefghij', 4)).toEqual(['abcd', 'efgh', 'ij'])
   })
 
+  it('measures wide characters by display width', () => {
+    // Each CJK glyph is 2 cells wide, so only two fit per 4-cell line.
+    expect(wrapText('日本語', 4)).toEqual(['日本', '語'])
+  })
+
   it('preserves paragraph breaks', () => {
     expect(wrapText('one\n\ntwo', 10)).toEqual(['one', '', 'two'])
   })

--- a/packages/tui/src/format.test.ts
+++ b/packages/tui/src/format.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { domain, formatCount, relativeTime, wrapText } from './format.ts'
+
+const now = new Date('2026-06-10T12:00:00Z')
+
+describe('relativeTime', () => {
+  it('handles just-now', () => {
+    expect(relativeTime('2026-06-10T11:59:50Z', now)).toBe('now')
+  })
+
+  it('formats minutes, hours, days, weeks, months and years', () => {
+    expect(relativeTime('2026-06-10T11:55:00Z', now)).toBe('5m')
+    expect(relativeTime('2026-06-10T09:00:00Z', now)).toBe('3h')
+    expect(relativeTime('2026-06-08T12:00:00Z', now)).toBe('2d')
+    expect(relativeTime('2026-05-20T12:00:00Z', now)).toBe('3w')
+    expect(relativeTime('2026-02-10T12:00:00Z', now)).toBe('4mo')
+    expect(relativeTime('2024-06-10T12:00:00Z', now)).toBe('2y')
+  })
+
+  it('returns empty for invalid dates', () => {
+    expect(relativeTime('not-a-date', now)).toBe('')
+  })
+})
+
+describe('domain', () => {
+  it('extracts the hostname without www', () => {
+    expect(domain('https://www.example.com/a/b?c=1')).toBe('example.com')
+    expect(domain('https://zander.wtf')).toBe('zander.wtf')
+  })
+
+  it('returns empty for invalid or missing urls', () => {
+    expect(domain('not a url')).toBe('')
+    expect(domain(null)).toBe('')
+  })
+})
+
+describe('formatCount', () => {
+  it('adds thousand separators', () => {
+    expect(formatCount(1234)).toBe('1,234')
+  })
+})
+
+describe('wrapText', () => {
+  it('wraps on word boundaries', () => {
+    expect(wrapText('the quick brown fox jumps', 10)).toEqual([
+      'the quick',
+      'brown fox',
+      'jumps',
+    ])
+  })
+
+  it('hard-breaks words longer than the width', () => {
+    expect(wrapText('abcdefghij', 4)).toEqual(['abcd', 'efgh', 'ij'])
+  })
+
+  it('preserves paragraph breaks', () => {
+    expect(wrapText('one\n\ntwo', 10)).toEqual(['one', '', 'two'])
+  })
+
+  it('returns nothing for zero width', () => {
+    expect(wrapText('anything', 0)).toEqual([])
+  })
+})

--- a/packages/tui/src/format.ts
+++ b/packages/tui/src/format.ts
@@ -1,0 +1,92 @@
+/** Pure text formatting helpers. */
+
+const UNITS: [seconds: number, suffix: string][] = [
+  [60, 's'],
+  [3600, 'm'],
+  [86400, 'h'],
+  [604800, 'd'],
+  [2629800, 'w'],
+  [31557600, 'mo'],
+]
+
+/** Compact relative time: "now", "5m", "3h", "2d", "6w", "4mo", "2y". */
+export const relativeTime = (iso: string, now = new Date()) => {
+  const seconds = Math.floor((now.getTime() - new Date(iso).getTime()) / 1000)
+
+  if (Number.isNaN(seconds)) {
+    return ''
+  }
+
+  if (seconds < 45) {
+    return 'now'
+  }
+
+  let previousThreshold = 60
+
+  for (const [threshold, suffix] of UNITS.slice(1)) {
+    if (seconds < threshold) {
+      return `${Math.round(seconds / previousThreshold)}${suffix}`
+    }
+
+    previousThreshold = threshold
+  }
+
+  return `${Math.round(seconds / 31557600)}y`
+}
+
+/** Hostname of a URL without the www. prefix; '' when unparseable. */
+export const domain = (url: string | null | undefined) => {
+  if (!url) {
+    return ''
+  }
+
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return ''
+  }
+}
+
+export const formatCount = (value: number) => value.toLocaleString('en-US')
+
+/** Greedy word-wrap of plain text into lines no wider than `width`. */
+export const wrapText = (text: string, width: number): string[] => {
+  if (width <= 0) {
+    return []
+  }
+
+  const lines: string[] = []
+
+  for (const paragraph of text.split(/\r?\n/)) {
+    if (!paragraph.trim()) {
+      lines.push('')
+      continue
+    }
+
+    let line = ''
+
+    for (const word of paragraph.split(/\s+/)) {
+      if (!line) {
+        line = word
+      } else if (`${line} ${word}`.length <= width) {
+        line = `${line} ${word}`
+      } else {
+        lines.push(line)
+        line = word
+      }
+
+      while (line.length > width) {
+        lines.push(line.slice(0, width))
+        line = line.slice(width)
+      }
+    }
+
+    lines.push(line)
+  }
+
+  while (lines.length && lines[lines.length - 1] === '') {
+    lines.pop()
+  }
+
+  return lines
+}

--- a/packages/tui/src/format.ts
+++ b/packages/tui/src/format.ts
@@ -1,5 +1,26 @@
 /** Pure text formatting helpers. */
 
+import { charWidth, stringWidth } from './ansi.ts'
+
+/** Take the longest prefix of `text` that fits within `width` display cells. */
+const sliceToWidth = (text: string, width: number) => {
+  let used = 0
+  let result = ''
+
+  for (const char of text) {
+    const next = used + charWidth(char.codePointAt(0) ?? 0)
+
+    if (next > width) {
+      break
+    }
+
+    result += char
+    used = next
+  }
+
+  return result
+}
+
 const UNITS: [seconds: number, suffix: string][] = [
   [60, 's'],
   [3600, 'm'],
@@ -68,16 +89,19 @@ export const wrapText = (text: string, width: number): string[] => {
     for (const word of paragraph.split(/\s+/)) {
       if (!line) {
         line = word
-      } else if (`${line} ${word}`.length <= width) {
+      } else if (stringWidth(`${line} ${word}`) <= width) {
         line = `${line} ${word}`
       } else {
         lines.push(line)
         line = word
       }
 
-      while (line.length > width) {
-        lines.push(line.slice(0, width))
-        line = line.slice(width)
+      while (stringWidth(line) > width) {
+        // Force at least one code point of progress so a single character wider
+        // than `width` (e.g. a CJK glyph in a 1-cell panel) can't loop forever.
+        const chunk = sliceToWidth(line, width) || (Array.from(line)[0] ?? '')
+        lines.push(chunk)
+        line = line.slice(chunk.length)
       }
     }
 

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -41,14 +41,36 @@ const version = () => {
 const runLogin = async (): Promise<OtterConfig> => {
   const rl = createInterface({ input: process.stdin, output: process.stdout })
 
+  // Suppress echo while the API key is typed so the secret never lands on
+  // screen (or in the terminal's scrollback). readline routes every write —
+  // prompt and keystrokes alike — through `_writeToOutput`, so we print the
+  // prompt ourselves first, then mask everything but the submitting newline.
+  let masked = false
+  const iface = rl as unknown as {
+    output: { write: (text: string) => void }
+    _writeToOutput?: (text: string) => void
+  }
+  iface._writeToOutput = (text: string) => {
+    if (masked) {
+      if (text.includes('\n')) {
+        iface.output.write('\n')
+      }
+
+      return
+    }
+
+    iface.output.write(text)
+  }
+
   try {
     console.log('🦦 Connect otter-tui to your Otter instance\n')
     const baseUrl = (
       await rl.question('Otter URL (e.g. https://otter.example.com): ')
     ).trim()
-    const apiKey = (
-      await rl.question('API key (Otter → Settings → API key): ')
-    ).trim()
+    process.stdout.write('API key (Otter → Settings → API key): ')
+    masked = true
+    const apiKey = (await rl.question('')).trim()
+    masked = false
 
     if (!baseUrl || !apiKey) {
       throw new Error('Both a URL and an API key are required')

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+import { createInterface } from 'node:readline/promises'
+import { OtterClient } from './api.ts'
+import { App } from './app.ts'
+import {
+  configPath,
+  loadConfig,
+  type OtterConfig,
+  saveConfig,
+} from './config.ts'
+
+const HELP = `🦦 otter-tui — a terminal UI for Otter
+
+Usage
+  otter-tui              browse your bookmarks
+  otter-tui login        configure the Otter URL + API key
+  otter-tui add <url> [tag ...]
+                         save a bookmark (Otter scrapes the page)
+  otter-tui --help       show this help
+  otter-tui --version    show the version
+
+Configuration
+  Reads OTTER_BASE_URL and OTTER_API_KEY, falling back to
+  ${configPath()} (written by \`otter-tui login\`).
+  Your API key lives in Otter under Settings.
+`
+
+const version = () => {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as { version?: string }
+
+    return pkg.version ?? '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
+
+const runLogin = async (): Promise<OtterConfig> => {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+
+  try {
+    console.log('🦦 Connect otter-tui to your Otter instance\n')
+    const baseUrl = (
+      await rl.question('Otter URL (e.g. https://otter.example.com): ')
+    ).trim()
+    const apiKey = (
+      await rl.question('API key (Otter → Settings → API key): ')
+    ).trim()
+
+    if (!baseUrl || !apiKey) {
+      throw new Error('Both a URL and an API key are required')
+    }
+
+    const config: OtterConfig = {
+      apiKey,
+      baseUrl: baseUrl.replace(/\/+$/, ''),
+    }
+    const client = new OtterClient(config)
+    process.stdout.write('\nChecking credentials… ')
+    const profile = await client.me()
+    console.log(`ok — hello ${profile.username ?? 'there'}!`)
+    const path = saveConfig(config)
+    console.log(`Saved to ${path}`)
+
+    return config
+  } finally {
+    rl.close()
+  }
+}
+
+const runQuickAdd = async (args: string[]) => {
+  const [url, ...tags] = args
+
+  if (!url) {
+    throw new Error('Usage: otter-tui add <url> [tag ...]')
+  }
+
+  const config = loadConfig()
+
+  if (!config) {
+    throw new Error('Not configured — run `otter-tui login` first')
+  }
+
+  const client = new OtterClient(config)
+  console.log(`🦦 Saving ${url}…`)
+  const [saved] = await client.addBookmark(url, tags)
+  console.log(`Saved “${saved?.title || url}” (${saved?.id})`)
+
+  if (saved?.tags?.length) {
+    console.log(`Tags: ${saved.tags.map((tag) => `#${tag}`).join(' ')}`)
+  }
+}
+
+const main = async () => {
+  const [command, ...rest] = process.argv.slice(2)
+
+  if (command === '--help' || command === '-h') {
+    console.log(HELP)
+    return
+  }
+
+  if (command === '--version' || command === '-v') {
+    console.log(version())
+    return
+  }
+
+  if (command === 'login') {
+    await runLogin()
+    return
+  }
+
+  if (command === 'add') {
+    await runQuickAdd(rest)
+    return
+  }
+
+  if (command) {
+    throw new Error(`Unknown command “${command}” — try otter-tui --help`)
+  }
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error('otter-tui needs an interactive terminal')
+  }
+
+  const config = loadConfig() ?? (await runLogin())
+  new App(new OtterClient(config)).start()
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/packages/tui/src/keys.test.ts
+++ b/packages/tui/src/keys.test.ts
@@ -1,51 +1,53 @@
 import { describe, expect, it } from 'vitest'
 import { parseInput } from './keys.ts'
 
+const keysOf = (input: string) => parseInput(input).keys
+
 describe('parseInput', () => {
   it('parses printable characters', () => {
-    expect(parseInput('a')).toEqual([{ char: 'a', name: 'char' }])
+    expect(keysOf('a')).toEqual([{ char: 'a', name: 'char' }])
   })
 
   it('parses multi-byte characters as single keys', () => {
-    expect(parseInput('🦦')).toEqual([{ char: '🦦', name: 'char' }])
+    expect(keysOf('🦦')).toEqual([{ char: '🦦', name: 'char' }])
   })
 
   it('parses enter, tab and backspace', () => {
-    expect(parseInput('\r')).toEqual([{ name: 'enter' }])
-    expect(parseInput('\t')).toEqual([{ name: 'tab' }])
-    expect(parseInput('\x7f')).toEqual([{ name: 'backspace' }])
+    expect(keysOf('\r')).toEqual([{ name: 'enter' }])
+    expect(keysOf('\t')).toEqual([{ name: 'tab' }])
+    expect(keysOf('\x7f')).toEqual([{ name: 'backspace' }])
   })
 
   it('parses control characters', () => {
-    expect(parseInput('\x03')).toEqual([{ ctrl: true, name: 'c' }])
-    expect(parseInput('\x15')).toEqual([{ ctrl: true, name: 'u' }])
+    expect(keysOf('\x03')).toEqual([{ ctrl: true, name: 'c' }])
+    expect(keysOf('\x15')).toEqual([{ ctrl: true, name: 'u' }])
   })
 
   it('parses arrow keys (CSI)', () => {
-    expect(parseInput('\x1b[A')).toEqual([{ name: 'up' }])
-    expect(parseInput('\x1b[B')).toEqual([{ name: 'down' }])
-    expect(parseInput('\x1b[C')).toEqual([{ name: 'right' }])
-    expect(parseInput('\x1b[D')).toEqual([{ name: 'left' }])
+    expect(keysOf('\x1b[A')).toEqual([{ name: 'up' }])
+    expect(keysOf('\x1b[B')).toEqual([{ name: 'down' }])
+    expect(keysOf('\x1b[C')).toEqual([{ name: 'right' }])
+    expect(keysOf('\x1b[D')).toEqual([{ name: 'left' }])
   })
 
   it('parses arrow keys (SS3)', () => {
-    expect(parseInput('\x1bOA')).toEqual([{ name: 'up' }])
+    expect(keysOf('\x1bOA')).toEqual([{ name: 'up' }])
   })
 
   it('parses home/end/page keys', () => {
-    expect(parseInput('\x1b[H')).toEqual([{ name: 'home' }])
-    expect(parseInput('\x1b[F')).toEqual([{ name: 'end' }])
-    expect(parseInput('\x1b[5~')).toEqual([{ name: 'pageup' }])
-    expect(parseInput('\x1b[6~')).toEqual([{ name: 'pagedown' }])
-    expect(parseInput('\x1b[3~')).toEqual([{ name: 'delete' }])
+    expect(keysOf('\x1b[H')).toEqual([{ name: 'home' }])
+    expect(keysOf('\x1b[F')).toEqual([{ name: 'end' }])
+    expect(keysOf('\x1b[5~')).toEqual([{ name: 'pageup' }])
+    expect(keysOf('\x1b[6~')).toEqual([{ name: 'pagedown' }])
+    expect(keysOf('\x1b[3~')).toEqual([{ name: 'delete' }])
   })
 
   it('parses a bare escape', () => {
-    expect(parseInput('\x1b')).toEqual([{ name: 'escape' }])
+    expect(parseInput('\x1b')).toEqual({ keys: [{ name: 'escape' }], rest: '' })
   })
 
   it('parses a pasted chunk into multiple keys', () => {
-    expect(parseInput('hi\r')).toEqual([
+    expect(keysOf('hi\r')).toEqual([
       { char: 'h', name: 'char' },
       { char: 'i', name: 'char' },
       { name: 'enter' },
@@ -53,6 +55,23 @@ describe('parseInput', () => {
   })
 
   it('ignores unknown CSI sequences gracefully', () => {
-    expect(parseInput('\x1b[99~')).toEqual([{ name: 'unknown' }])
+    expect(keysOf('\x1b[99~')).toEqual([{ name: 'unknown' }])
+  })
+
+  it('buffers an incomplete CSI sequence as rest', () => {
+    expect(parseInput('a\x1b[')).toEqual({
+      keys: [{ char: 'a', name: 'char' }],
+      rest: '\x1b[',
+    })
+  })
+
+  it('buffers an incomplete SS3 sequence as rest', () => {
+    expect(parseInput('\x1bO')).toEqual({ keys: [], rest: '\x1bO' })
+  })
+
+  it('reassembles a sequence split across two chunks', () => {
+    const first = parseInput('\x1b[')
+    expect(first.keys).toEqual([])
+    expect(parseInput(`${first.rest}A`).keys).toEqual([{ name: 'up' }])
   })
 })

--- a/packages/tui/src/keys.test.ts
+++ b/packages/tui/src/keys.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { parseInput } from './keys.ts'
+
+describe('parseInput', () => {
+  it('parses printable characters', () => {
+    expect(parseInput('a')).toEqual([{ char: 'a', name: 'char' }])
+  })
+
+  it('parses multi-byte characters as single keys', () => {
+    expect(parseInput('🦦')).toEqual([{ char: '🦦', name: 'char' }])
+  })
+
+  it('parses enter, tab and backspace', () => {
+    expect(parseInput('\r')).toEqual([{ name: 'enter' }])
+    expect(parseInput('\t')).toEqual([{ name: 'tab' }])
+    expect(parseInput('\x7f')).toEqual([{ name: 'backspace' }])
+  })
+
+  it('parses control characters', () => {
+    expect(parseInput('\x03')).toEqual([{ ctrl: true, name: 'c' }])
+    expect(parseInput('\x15')).toEqual([{ ctrl: true, name: 'u' }])
+  })
+
+  it('parses arrow keys (CSI)', () => {
+    expect(parseInput('\x1b[A')).toEqual([{ name: 'up' }])
+    expect(parseInput('\x1b[B')).toEqual([{ name: 'down' }])
+    expect(parseInput('\x1b[C')).toEqual([{ name: 'right' }])
+    expect(parseInput('\x1b[D')).toEqual([{ name: 'left' }])
+  })
+
+  it('parses arrow keys (SS3)', () => {
+    expect(parseInput('\x1bOA')).toEqual([{ name: 'up' }])
+  })
+
+  it('parses home/end/page keys', () => {
+    expect(parseInput('\x1b[H')).toEqual([{ name: 'home' }])
+    expect(parseInput('\x1b[F')).toEqual([{ name: 'end' }])
+    expect(parseInput('\x1b[5~')).toEqual([{ name: 'pageup' }])
+    expect(parseInput('\x1b[6~')).toEqual([{ name: 'pagedown' }])
+    expect(parseInput('\x1b[3~')).toEqual([{ name: 'delete' }])
+  })
+
+  it('parses a bare escape', () => {
+    expect(parseInput('\x1b')).toEqual([{ name: 'escape' }])
+  })
+
+  it('parses a pasted chunk into multiple keys', () => {
+    expect(parseInput('hi\r')).toEqual([
+      { char: 'h', name: 'char' },
+      { char: 'i', name: 'char' },
+      { name: 'enter' },
+    ])
+  })
+
+  it('ignores unknown CSI sequences gracefully', () => {
+    expect(parseInput('\x1b[99~')).toEqual([{ name: 'unknown' }])
+  })
+})

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -1,0 +1,125 @@
+/** Parse raw stdin chunks into named key events. Pure and testable. */
+
+export interface Key {
+  name: string
+  char?: string
+  ctrl?: boolean
+}
+
+const CSI_FINAL: Record<string, string> = {
+  A: 'up',
+  B: 'down',
+  C: 'right',
+  D: 'left',
+  F: 'end',
+  H: 'home',
+  Z: 'shift-tab',
+}
+
+const CSI_TILDE: Record<string, string> = {
+  '1': 'home',
+  '3': 'delete',
+  '4': 'end',
+  '5': 'pageup',
+  '6': 'pagedown',
+  '7': 'home',
+  '8': 'end',
+}
+
+const SS3: Record<string, string> = {
+  A: 'up',
+  B: 'down',
+  C: 'right',
+  D: 'left',
+  F: 'end',
+  H: 'home',
+}
+
+const csiToKey = (finalByte: string, params: string): Key => {
+  if (finalByte === '~') {
+    const name = CSI_TILDE[params.split(';')[0] ?? '']
+
+    return name ? { name } : { name: 'unknown' }
+  }
+
+  const name = CSI_FINAL[finalByte]
+
+  return name ? { name } : { name: 'unknown' }
+}
+
+export const parseInput = (input: string): Key[] => {
+  const keys: Key[] = []
+  let index = 0
+
+  while (index < input.length) {
+    const char = input[index]
+
+    if (char === '\x1b') {
+      const next = input[index + 1]
+
+      if (next === '[') {
+        let end = index + 2
+
+        while (
+          end < input.length &&
+          !(input.charCodeAt(end) >= 0x40 && input.charCodeAt(end) <= 0x7e)
+        ) {
+          end += 1
+        }
+
+        if (end >= input.length) {
+          keys.push({ name: 'escape' })
+          break
+        }
+
+        keys.push(csiToKey(input[end] as string, input.slice(index + 2, end)))
+        index = end + 1
+        continue
+      }
+
+      if (next === 'O' && index + 2 < input.length) {
+        const name = SS3[input[index + 2] as string]
+        keys.push(name ? { name } : { name: 'unknown' })
+        index += 3
+        continue
+      }
+
+      keys.push({ name: 'escape' })
+      index += 1
+      continue
+    }
+
+    if (char === '\r' || char === '\n') {
+      keys.push({ name: 'enter' })
+      index += 1
+      continue
+    }
+
+    if (char === '\t') {
+      keys.push({ name: 'tab' })
+      index += 1
+      continue
+    }
+
+    if (char === '\x7f' || char === '\b') {
+      keys.push({ name: 'backspace' })
+      index += 1
+      continue
+    }
+
+    const code = input.charCodeAt(index)
+
+    if (code < 0x20) {
+      keys.push({ ctrl: true, name: String.fromCharCode(code + 96) })
+      index += 1
+      continue
+    }
+
+    const codePoint = input.codePointAt(index) ?? code
+    const printable = String.fromCodePoint(codePoint)
+    keys.push({ char: printable, name: 'char' })
+    index += printable.length
+  }
+
+  return keys
+}

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -47,7 +47,13 @@ const csiToKey = (finalByte: string, params: string): Key => {
   return name ? { name } : { name: 'unknown' }
 }
 
-export const parseInput = (input: string): Key[] => {
+/**
+ * Parse a chunk of stdin into key events. A trailing *incomplete* escape
+ * sequence (CSI/SS3 split across terminal reads) is not guessed at — it's
+ * returned in `rest` so the caller can prepend it to the next chunk. A lone
+ * `ESC` is still emitted immediately, so the Escape key stays responsive.
+ */
+export const parseInput = (input: string): { keys: Key[]; rest: string } => {
   const keys: Key[] = []
   let index = 0
 
@@ -68,8 +74,8 @@ export const parseInput = (input: string): Key[] => {
         }
 
         if (end >= input.length) {
-          keys.push({ name: 'escape' })
-          break
+          // Incomplete CSI — hand the tail back to be buffered.
+          return { keys, rest: input.slice(index) }
         }
 
         keys.push(csiToKey(input[end] as string, input.slice(index + 2, end)))
@@ -77,7 +83,12 @@ export const parseInput = (input: string): Key[] => {
         continue
       }
 
-      if (next === 'O' && index + 2 < input.length) {
+      if (next === 'O') {
+        if (index + 2 >= input.length) {
+          // Incomplete SS3 — hand the tail back to be buffered.
+          return { keys, rest: input.slice(index) }
+        }
+
         const name = SS3[input[index + 2] as string]
         keys.push(name ? { name } : { name: 'unknown' })
         index += 3
@@ -121,5 +132,5 @@ export const parseInput = (input: string): Key[] => {
     index += printable.length
   }
 
-  return keys
+  return { keys, rest: '' }
 }

--- a/packages/tui/src/state.ts
+++ b/packages/tui/src/state.ts
@@ -28,7 +28,6 @@ export interface AppState {
   tagInput: string
   tags: TagCount[]
   typeFilter: string | null
-  username: string
 }
 
 export const initialState = (): AppState => ({
@@ -49,7 +48,6 @@ export const initialState = (): AppState => ({
   tagInput: '',
   tags: [],
   typeFilter: null,
-  username: '',
 })
 
 /** Bookmark types the `c` key cycles through (subset of the API's types). */

--- a/packages/tui/src/state.ts
+++ b/packages/tui/src/state.ts
@@ -1,0 +1,66 @@
+import type { Bookmark, TagCount } from './api.ts'
+
+export type Mode =
+  | 'add'
+  | 'confirm-delete'
+  | 'detail'
+  | 'help'
+  | 'list'
+  | 'search'
+  | 'tags'
+
+export interface AppState {
+  count: number
+  /** text buffer for search/add input modes */
+  input: string
+  items: Bookmark[]
+  loading: boolean
+  mode: Mode
+  offset: number
+  pageSize: number
+  query: string
+  selected: number
+  starOnly: boolean
+  status: string
+  statusKind: 'error' | 'info'
+  tag: string | null
+  tagCursor: number
+  tagInput: string
+  tags: TagCount[]
+  typeFilter: string | null
+  username: string
+}
+
+export const initialState = (): AppState => ({
+  count: 0,
+  input: '',
+  items: [],
+  loading: true,
+  mode: 'list',
+  offset: 0,
+  pageSize: 10,
+  query: '',
+  selected: 0,
+  starOnly: false,
+  status: '',
+  statusKind: 'info',
+  tag: null,
+  tagCursor: 0,
+  tagInput: '',
+  tags: [],
+  typeFilter: null,
+  username: '',
+})
+
+/** Bookmark types the `c` key cycles through (subset of the API's types). */
+export const TYPE_CYCLE = [
+  null,
+  'article',
+  'link',
+  'video',
+  'audio',
+  'recipe',
+  'image',
+  'document',
+  'note',
+] as const

--- a/packages/tui/src/ui.ts
+++ b/packages/tui/src/ui.ts
@@ -174,7 +174,8 @@ const panel = (
   width: number,
   bodyHeight: number,
 ) => {
-  const innerWidth = Math.min(width - 6, 76)
+  // Clamp to ≥0 so a very narrow terminal can't drive `.repeat()` negative.
+  const innerWidth = Math.max(0, Math.min(width - 6, 76))
   const top = `╭─ ${title} ${'─'.repeat(Math.max(0, innerWidth - stringWidth(title) - 3))}╮`
   const bottom = `╰${'─'.repeat(innerWidth)}╯`
   const body = content

--- a/packages/tui/src/ui.ts
+++ b/packages/tui/src/ui.ts
@@ -1,0 +1,380 @@
+import {
+  bold,
+  cursor,
+  dim,
+  fg,
+  italic,
+  padToWidth,
+  palette,
+  screen,
+  stringWidth,
+  truncate,
+} from './ansi.ts'
+import type { Bookmark, TagCount } from './api.ts'
+import { domain, formatCount, relativeTime, wrapText } from './format.ts'
+import type { AppState } from './state.ts'
+
+const accent = fg(palette.accent)
+const muted = fg(palette.muted)
+const danger = fg(palette.danger)
+const starColor = fg(palette.star)
+const tagColor = fg(palette.tag)
+const urlColor = fg(palette.url)
+const borderColor = fg(palette.border)
+
+const CURSOR_BLOCK = '▌'
+
+export const visibleItems = (height: number) =>
+  Math.max(1, Math.floor((height - 4) / 2))
+
+const filterChips = (state: AppState) => {
+  const chips: string[] = []
+
+  if (state.query) {
+    chips.push(italic(`“${state.query}”`))
+  }
+
+  if (state.starOnly) {
+    chips.push(starColor('★ starred'))
+  }
+
+  if (state.tag) {
+    chips.push(tagColor(`#${state.tag}`))
+  }
+
+  if (state.typeFilter) {
+    chips.push(urlColor(state.typeFilter))
+  }
+
+  return chips.length ? chips.join(dim(' · ')) : dim('all bookmarks')
+}
+
+const header = (state: AppState, width: number) => {
+  const left = ` ${accent(bold('🦦 Otter'))}  ${filterChips(state)}`
+  const page = Math.floor(state.offset / state.pageSize) + 1
+  const pages = Math.max(1, Math.ceil(state.count / state.pageSize))
+  const right = `${muted(
+    `${formatCount(state.count)} saved · page ${page}/${pages}`,
+  )} `
+  const gap = width - stringWidth(left) - stringWidth(right)
+
+  if (gap < 1) {
+    return left
+  }
+
+  return left + ' '.repeat(gap) + right
+}
+
+const bookmarkLines = (
+  bookmark: Bookmark,
+  selected: boolean,
+  width: number,
+) => {
+  const marker = selected ? accent('❯ ') : '  '
+  const star = bookmark.star ? starColor('★ ') : '  '
+  const type = bookmark.type ?? ''
+  const titleMax = width - 4 - (type ? stringWidth(type) + 2 : 0) - 1
+  const rawTitle = bookmark.title || bookmark.url || '(untitled)'
+  const title = truncate(rawTitle, Math.max(titleMax, 8))
+  const styledTitle = selected ? bold(title) : title
+  const gap =
+    width - 4 - stringWidth(title) - (type ? stringWidth(type) : 0) - 1
+  const lineOne =
+    marker +
+    star +
+    styledTitle +
+    (type && gap > 0 ? ' '.repeat(gap) + muted(type) : '')
+
+  const metaParts: string[] = []
+  const host = domain(bookmark.url)
+
+  if (host) {
+    metaParts.push(host)
+  }
+
+  for (const tag of bookmark.tags ?? []) {
+    metaParts.push(`#${tag}`)
+  }
+
+  metaParts.push(relativeTime(bookmark.created_at))
+
+  let plainMeta = metaParts.join(' · ')
+  plainMeta = truncate(plainMeta, width - 5)
+  const styledMeta = plainMeta
+    .split(' · ')
+    .map((part) => {
+      if (part.startsWith('#')) {
+        return tagColor(part)
+      }
+
+      if (part === host) {
+        return urlColor(part)
+      }
+
+      return muted(part)
+    })
+    .join(dim(' · '))
+
+  return [lineOne, `    ${styledMeta}`]
+}
+
+const listBody = (state: AppState, width: number, bodyHeight: number) => {
+  const lines: string[] = []
+
+  if (!state.items.length) {
+    const message = state.loading ? 'fetching bookmarks…' : 'No bookmarks found'
+    const hint = state.loading
+      ? ''
+      : state.query || state.tag || state.starOnly || state.typeFilter
+        ? 'press x to clear filters'
+        : 'press a to add your first bookmark'
+    const top = Math.max(0, Math.floor(bodyHeight / 2) - 1)
+
+    for (let i = 0; i < top; i += 1) {
+      lines.push('')
+    }
+
+    lines.push(center(muted(message), width))
+
+    if (hint) {
+      lines.push(center(dim(hint), width))
+    }
+
+    return lines
+  }
+
+  for (const [index, bookmark] of state.items.entries()) {
+    if (lines.length + 2 > bodyHeight) {
+      break
+    }
+
+    lines.push(...bookmarkLines(bookmark, index === state.selected, width))
+  }
+
+  return lines
+}
+
+const center = (text: string, width: number) => {
+  const padding = Math.max(0, Math.floor((width - stringWidth(text)) / 2))
+
+  return ' '.repeat(padding) + text
+}
+
+const panel = (
+  title: string,
+  content: string[],
+  width: number,
+  bodyHeight: number,
+) => {
+  const innerWidth = Math.min(width - 6, 76)
+  const top = `╭─ ${title} ${'─'.repeat(Math.max(0, innerWidth - stringWidth(title) - 3))}╮`
+  const bottom = `╰${'─'.repeat(innerWidth)}╯`
+  const body = content
+    .slice(0, bodyHeight - 2)
+    .map(
+      (line) =>
+        `${borderColor('│')} ${padToWidth(line, innerWidth - 2)} ${borderColor('│')}`,
+    )
+  const lines = [borderColor(top), ...body, borderColor(bottom)]
+  const leftPad = ' '.repeat(
+    Math.max(0, Math.floor((width - innerWidth - 2) / 2)),
+  )
+
+  return lines.map((line) => leftPad + line)
+}
+
+const helpBody = (width: number, bodyHeight: number) => {
+  const entry = (key: string, label: string) =>
+    `${accent(key.padEnd(11))}${label}`
+  const content = [
+    '',
+    entry('↑/↓ j/k', 'move selection'),
+    entry('←/→ h/l', 'previous / next page'),
+    entry('enter o', 'open in browser'),
+    entry('i', 'bookmark details'),
+    entry('/', 'search'),
+    entry('a', 'add a bookmark (scrapes the URL)'),
+    entry('s', 'star / unstar'),
+    entry('d', 'delete (asks first)'),
+    entry('f', 'toggle starred filter'),
+    entry('t', 'filter by tag'),
+    entry('c', 'cycle type filter'),
+    entry('x', 'clear search + filters'),
+    entry('r', 'refresh'),
+    entry('q', 'quit'),
+    '',
+    dim(`config: OTTER_BASE_URL / OTTER_API_KEY or otter-tui login`),
+  ]
+
+  return panel('help', content, width, bodyHeight)
+}
+
+const detailBody = (state: AppState, width: number, bodyHeight: number) => {
+  const bookmark = state.items[state.selected]
+
+  if (!bookmark) {
+    return [center(muted('nothing selected'), width)]
+  }
+
+  const innerWidth = Math.min(width - 6, 76) - 2
+  const content: string[] = ['']
+
+  for (const line of wrapText(bookmark.title || '(untitled)', innerWidth)) {
+    content.push(bold(line))
+  }
+
+  if (bookmark.url) {
+    for (const line of wrapText(bookmark.url, innerWidth)) {
+      content.push(urlColor(line))
+    }
+  }
+
+  content.push('')
+
+  const meta = [
+    bookmark.type ?? 'link',
+    bookmark.star ? '★ starred' : null,
+    bookmark.public ? 'public' : null,
+    `${bookmark.click_count} click${bookmark.click_count === 1 ? '' : 's'}`,
+    `saved ${relativeTime(bookmark.created_at)} ago`,
+  ].filter(Boolean)
+  content.push(muted(meta.join(' · ')))
+
+  if (bookmark.tags?.length) {
+    content.push(tagColor(bookmark.tags.map((tag) => `#${tag}`).join(' ')))
+  }
+
+  if (bookmark.description) {
+    content.push('')
+
+    for (const line of wrapText(bookmark.description, innerWidth)) {
+      content.push(line)
+    }
+  }
+
+  if (bookmark.note) {
+    content.push('')
+    content.push(accent('note'))
+
+    for (const line of wrapText(bookmark.note, innerWidth)) {
+      content.push(italic(line))
+    }
+  }
+
+  content.push('')
+
+  return panel('details', content, width, bodyHeight)
+}
+
+const tagsBody = (state: AppState, width: number, bodyHeight: number) => {
+  const innerWidth = Math.min(width - 6, 76) - 2
+  const matches = tagMatches(state.tags, state.tagInput)
+  const content: string[] = [
+    `${dim('filter:')} ${state.tagInput}${CURSOR_BLOCK}`,
+    '',
+  ]
+  const maxRows = Math.max(1, bodyHeight - 6)
+  const start = Math.max(
+    0,
+    Math.min(
+      state.tagCursor - Math.floor(maxRows / 2),
+      matches.length - maxRows,
+    ),
+  )
+
+  for (const [index, tag] of matches.slice(start, start + maxRows).entries()) {
+    const selected = start + index === state.tagCursor
+    const marker = selected ? accent('❯ ') : '  '
+    const label = truncate(`#${tag.tag}`, innerWidth - 8)
+    const line = `${marker}${selected ? bold(label) : tagColor(label)} ${muted(`(${tag.count})`)}`
+    content.push(line)
+  }
+
+  if (!matches.length) {
+    content.push(muted('  no matching tags'))
+  }
+
+  return panel('filter by tag', content, width, bodyHeight)
+}
+
+export const tagMatches = (tags: TagCount[], filter: string) =>
+  tags.filter((tag) => tag.tag.toLowerCase().includes(filter.toLowerCase()))
+
+const statusLine = (state: AppState, width: number) => {
+  if (state.mode === 'search') {
+    return ` ${accent('/')} ${state.input}${CURSOR_BLOCK}`
+  }
+
+  if (state.mode === 'add') {
+    return ` ${accent('+ url:')} ${state.input}${CURSOR_BLOCK}`
+  }
+
+  if (state.mode === 'confirm-delete') {
+    const bookmark = state.items[state.selected]
+    const title = truncate(
+      bookmark?.title || bookmark?.url || 'this bookmark',
+      width - 24,
+    )
+
+    return ` ${danger(`delete “${title}”? `)}${bold('y')}${dim('/')}${bold('N')}`
+  }
+
+  if (state.loading) {
+    return ` ${muted('loading…')}`
+  }
+
+  if (state.status) {
+    const colorise = state.statusKind === 'error' ? danger : muted
+
+    return ` ${colorise(truncate(state.status, width - 2))}`
+  }
+
+  return ''
+}
+
+const FOOTER_HINTS: Partial<Record<AppState['mode'], string>> = {
+  add: '⏎ save · esc cancel',
+  'confirm-delete': 'y delete · n cancel',
+  detail: 'j/k prev/next · ⏎ open · s star · esc back',
+  help: 'press any key to close',
+  list: '⏎ open · / search · a add · s star · d delete · t tag · i details · ? help · q quit',
+  search: '⏎ search · esc cancel',
+  tags: 'type to filter · ⏎ apply · esc close',
+}
+
+export const renderFrame = (state: AppState, width: number, height: number) => {
+  const bodyHeight = height - 4
+  let body: string[]
+
+  switch (state.mode) {
+    case 'help':
+      body = helpBody(width, bodyHeight)
+      break
+    case 'detail':
+      body = detailBody(state, width, bodyHeight)
+      break
+    case 'tags':
+      body = tagsBody(state, width, bodyHeight)
+      break
+    default:
+      body = listBody(state, width, bodyHeight)
+  }
+
+  while (body.length < bodyHeight) {
+    body.push('')
+  }
+
+  const lines = [
+    header(state, width),
+    borderColor('─'.repeat(width)),
+    ...body.slice(0, bodyHeight),
+    statusLine(state, width),
+    ` ${dim(truncate(FOOTER_HINTS[state.mode] ?? '', width - 2))}`,
+  ]
+
+  return (
+    cursor.home +
+    lines.map((line) => line + screen.clearLine).join('\n') +
+    screen.clearDown
+  )
+}

--- a/packages/tui/src/ui.ts
+++ b/packages/tui/src/ui.ts
@@ -24,8 +24,10 @@ const borderColor = fg(palette.border)
 
 const CURSOR_BLOCK = '▌'
 
+// Each bookmark renders as two lines plus a blank separator between items,
+// so N items occupy 3N - 1 rows.
 export const visibleItems = (height: number) =>
-  Math.max(1, Math.floor((height - 4) / 2))
+  Math.max(1, Math.floor((height - 3) / 3))
 
 const filterChips = (state: AppState) => {
   const chips: string[] = []
@@ -144,8 +146,14 @@ const listBody = (state: AppState, width: number, bodyHeight: number) => {
   }
 
   for (const [index, bookmark] of state.items.entries()) {
-    if (lines.length + 2 > bodyHeight) {
+    const needed = index === 0 ? 2 : 3
+
+    if (lines.length + needed > bodyHeight) {
       break
+    }
+
+    if (index > 0) {
+      lines.push('')
     }
 
     lines.push(...bookmarkLines(bookmark, index === state.selected, width))

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2023",
+    "types": ["node"],
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["src/**/*.test.ts"],
+  "include": ["src"]
+}

--- a/packages/web/worker/search/search.ts
+++ b/packages/web/worker/search/search.ts
@@ -23,6 +23,18 @@ import type { WorkerEnv } from '../env'
 
 type HonoContext = Context<{ Bindings: WorkerEnv }>
 
+const parseBoolean = (value: unknown) => {
+  if (value === true || value === 'true') {
+    return true
+  }
+
+  if (value === false || value === 'false') {
+    return false
+  }
+
+  return undefined
+}
+
 /**
  * /api/search?q=example
  * This endpoint searches bookmarks with API-key or session auth.
@@ -51,12 +63,16 @@ export const getSearch = async (context: HonoContext) => {
       order,
       status,
       type,
+      tag,
     } = apiParameters(searchParams)
+    const star = parseBoolean(searchParams.star)
     const pattern = `%${searchTerm}%`
     const where = and(
       eq(bookmarks.user, userId),
       status ? eq(bookmarks.status, status) : undefined,
       type ? eq(bookmarks.type, type as BookmarkType) : undefined,
+      star === undefined ? undefined : eq(bookmarks.star, star),
+      tag ? arrayContains(bookmarks.tags, [tag]) : undefined,
       or(
         ilike(bookmarks.title, pattern),
         ilike(bookmarks.url, pattern),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,18 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/tui:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.20
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.20)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)
+
   packages/web:
     dependencies:
       '@atproto/api':
@@ -135,7 +147,7 @@ importers:
         version: 0.19.3
       '@better-auth/oauth-provider':
         specifier: ^1.6.9
-        version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))
+        version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))
       '@dnd-kit/abstract':
         specifier: ^0.1.21
         version: 0.1.21
@@ -192,7 +204,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
+        version: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
       change-case:
         specifier: ^5.4.4
         version: 5.4.4
@@ -213,7 +225,7 @@ importers:
         version: 0.13.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
       email-validator:
         specifier: ^2.0.4
         version: 2.0.4
@@ -2409,10 +2421,6 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@neondatabase/serverless@1.1.0':
-    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
-    engines: {node: '>=19.0.0'}
-
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
@@ -4051,6 +4059,9 @@ packages:
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
+  '@types/node@22.19.20':
+    resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -4215,6 +4226,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -4330,6 +4342,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -4603,6 +4616,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
@@ -10320,12 +10334,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260313.1
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))':
+  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))':
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
 
   '@better-auth/kysely-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
     dependencies:
@@ -10344,12 +10358,12 @@ snapshots:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/oauth-provider@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))':
+  '@better-auth/oauth-provider@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)))(better-call@1.3.5(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
+      better-auth: 1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
       better-call: 1.3.5(zod@4.3.6)
       jose: 6.2.3
       zod: 4.3.6
@@ -11785,9 +11799,6 @@ snapshots:
       '@emnapi/core': 1.9.0
       '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
-    optional: true
-
-  '@neondatabase/serverless@1.1.0':
     optional: true
 
   '@noble/ciphers@2.2.0': {}
@@ -13493,6 +13504,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.19.20':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -13716,6 +13731,14 @@ snapshots:
       '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)
 
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
@@ -14110,10 +14133,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)):
+  better-auth@1.6.9(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))
+      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))
       '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
       '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -14131,7 +14154,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)
       pg: 8.20.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -14922,10 +14945,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260313.1
-      '@neondatabase/serverless': 1.1.0
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.20.0
       kysely: 0.28.16
@@ -19577,9 +19599,25 @@ snapshots:
       - supports-color
       - typescript
 
+  vite@7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.58.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.20
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      terser: 5.46.0
+      tsx: 4.21.0
+
   vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.8
@@ -19608,6 +19646,46 @@ snapshots:
       jiti: 2.6.1
       terser: 5.46.0
       tsx: 4.21.0
+
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.20)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.20
+      happy-dom: 20.8.4
+      jsdom: 28.1.0(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 2.1.3
       '@mrmartineau/kit':
         specifier: 'catalog:'
-        version: 0.1.0(@types/node@25.9.2)(eslint@8.57.1)(typescript@5.9.3)
+        version: 0.1.0(@types/node@25.9.2)(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.3(supports-color@8.1.1)(typescript@5.9.3))
@@ -131,14 +131,14 @@ importers:
   packages/tui:
     devDependencies:
       '@types/node':
-        specifier: ^22.15.0
-        version: 22.19.20
+        specifier: ^20.19.0
+        version: 20.19.39
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.20)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.39)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)
 
   packages/web:
     dependencies:
@@ -4168,9 +4168,6 @@ packages:
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
-
-  '@types/node@22.19.20':
-    resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
@@ -12115,14 +12112,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -12156,7 +12153,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -12207,9 +12204,9 @@ snapshots:
       - magicast
       - supports-color
 
-  '@mrmartineau/kit@0.1.0(@types/node@25.9.2)(eslint@8.57.1)(typescript@5.9.3)':
+  '@mrmartineau/kit@0.1.0(@types/node@25.9.2)(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      release-it: 19.2.4(@types/node@25.9.2)
+      release-it: 19.2.4(@types/node@25.9.2)(supports-color@8.1.1)
       typescript: 5.9.3
     optionalDependencies:
       eslint: 8.57.1
@@ -13859,7 +13856,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -13902,7 +13899,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
 
   '@types/har-format@1.2.16': {}
 
@@ -13926,7 +13923,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
 
   '@types/lodash.throttle@4.1.9':
     dependencies:
@@ -13946,10 +13943,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.19.20':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -13957,6 +13950,7 @@ snapshots:
   '@types/node@25.9.2':
     dependencies:
       undici-types: 7.24.6
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -13968,7 +13962,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -13997,7 +13991,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
 
   '@types/semver@7.7.1': {}
 
@@ -14016,11 +14010,11 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
 
   '@types/xml2js@0.4.14':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -14030,7 +14024,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
     optional: true
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)':
@@ -14178,13 +14172,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)
 
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0))':
     dependencies:
@@ -14832,7 +14826,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -14843,7 +14837,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -16020,7 +16014,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5:
+  get-uri@6.0.5(supports-color@8.1.1):
     dependencies:
       basic-ftp: 5.2.0
       data-uri-to-buffer: 6.0.2
@@ -16174,7 +16168,7 @@ snapshots:
 
   happy-dom@20.8.4:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -16575,7 +16569,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -16585,7 +16579,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -16612,7 +16606,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -16620,7 +16614,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -16637,13 +16631,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 20.19.39
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 20.19.39
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -17898,12 +17892,12 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0:
+  pac-proxy-agent@7.2.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 6.0.5
+      get-uri: 6.0.5(supports-color@8.1.1)
       http-proxy-agent: 7.0.2(supports-color@8.1.1)
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
       pac-resolver: 7.0.1
@@ -18574,14 +18568,14 @@ snapshots:
 
   protocols@2.0.2: {}
 
-  proxy-agent@6.5.0:
+  proxy-agent@6.5.0(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2(supports-color@8.1.1)
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
       proxy-from-env: 1.1.0
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -18975,7 +18969,7 @@ snapshots:
       open: 10.2.0
       ora: 9.0.0
       os-name: 6.1.0
-      proxy-agent: 6.5.0
+      proxy-agent: 6.5.0(supports-color@8.1.1)
       semver: 7.7.3
       tinyglobby: 0.2.15
       undici: 6.23.0
@@ -18987,7 +18981,7 @@ snapshots:
       - magicast
       - supports-color
 
-  release-it@19.2.4(@types/node@25.9.2):
+  release-it@19.2.4(@types/node@25.9.2)(supports-color@8.1.1):
     dependencies:
       '@nodeutils/defaults-deep': 1.1.0
       '@octokit/rest': 22.0.1
@@ -19005,7 +18999,7 @@ snapshots:
       open: 10.2.0
       ora: 9.0.0
       os-name: 6.1.0
-      proxy-agent: 6.5.0
+      proxy-agent: 6.5.0(supports-color@8.1.1)
       semver: 7.7.3
       tinyglobby: 0.2.15
       undici: 6.23.0
@@ -19894,7 +19888,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.24.6: {}
+  undici-types@7.24.6:
+    optional: true
 
   undici@6.23.0: {}
 
@@ -20131,7 +20126,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -20140,7 +20135,7 @@ snapshots:
       rollup: 4.58.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 20.19.39
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -20179,10 +20174,10 @@ snapshots:
       terser: 5.48.0
       tsx: 4.21.0
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.20)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.39)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -20199,11 +20194,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.19.20)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 22.19.20
+      '@types/node': 20.19.39
       happy-dom: 20.8.4
       jsdom: 28.1.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## 🦦 otter-tui

A new workspace package, `packages/tui` — a fast, **zero-runtime-dependency** terminal UI for Otter. It consumes the web Worker's REST API exactly like the other clients, authenticating with the profile API key as a `Bearer` token (`worker/context.ts` already supports this).

```
 🦦 Otter  ★ starred · #dev                          1,234 saved · page 2/66
─────────────────────────────────────────────────────────────────────────────
 ❯ ★ Building a terminal UI from scratch                              article
     zander.wtf · #dev · #tui · 3d
   ★ How Hyperdrive keeps Postgres close to your Worker                  link
     blog.cloudflare.com · #dev · #cloudflare · 2w

 opened zander.wtf
 ⏎ open · / search · a add · s star · d delete · t tag · i details · ? help · q quit
```

### Features
- **Browse + paginate** bookmarks (`GET /api/bookmarks`) with vim-style keys (`j/k/h/l`, arrows, page keys)
- **Search** (`/` → `GET /api/search`) across title/URL/description/note/tags
- **Filters**: starred (`f`), tag picker with type-to-filter (`t` → `GET /api/tags`), type cycle (`c`), clear all (`x`)
- **Actions**: open in browser + click tracking (`⏎`), star/unstar with optimistic update (`s`), delete with confirmation (`d`), add with server-side scraping (`a`)
- **Detail panel** (`i`) with wrapped description/note, and a help overlay (`?`)
- **CLI extras**: `otter-tui add <url> [tag …]` for quick saves, `otter-tui login` to configure (validates against `/api/me`, writes `~/.config/otter/config.json` with `0600`); `OTTER_BASE_URL`/`OTTER_API_KEY` env vars override

### Implementation
- No runtime dependencies — hand-rolled ANSI renderer (alt-screen, 256-colour, wide-char-aware width/truncation) and stdin key parser (CSI/SS3 escape sequences)
- The renderer (`src/ui.ts`) is a pure function of app state; input parsing, text measurement and formatting are pure modules with **31 unit tests** (vitest)
- TypeScript with `erasableSyntaxOnly` + `rewriteRelativeImportExtensions`, so `node src/index.ts` works directly during dev (Node ≥ 22.18) while `tsc` emits a runnable `dist/` for Node ≥ 20
- Root scripts `tui:build`/`tui:dev` added; package documented in `CLAUDE.md` and `packages/tui/README.md`

### Testing
- `pnpm --filter=@mrmartineau/otter-tui run build` — clean `tsc` build
- `pnpm --filter=@mrmartineau/otter-tui exec vitest run` — 31/31 passing
- `pnpm exec biome check packages/tui` — clean
- Smoke-tested `--help`/`--version`/unknown-command paths and rendered every UI mode (list, help, detail, tags, search, confirm-delete) against sample data

https://claude.ai/code/session_0119PAn5qKWTzyoShBZzT3zv

---
_Generated by [Claude Code](https://claude.ai/code/session_0119PAn5qKWTzyoShBZzT3zv)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@mrmartineau/otter-tui`, a zero-runtime-dependency terminal UI for Otter that talks to the worker REST API using your profile API key. Browse, search, filter, and save bookmarks from the shell.

- **New Features**
  - Browse and paginate (`GET /api/bookmarks`) with vim-style keys; open in browser with click tracking.
  - Search (`/` → `GET /api/search`) with filters: starred, tag picker (`GET /api/tags`), type cycle; clear all.
  - Actions: star/unstar (optimistic), delete with confirm, add with server-side scraping (`POST /api/new`); detail panel (`i`) and help (`?`).
  - CLI: `otter-tui`, `otter-tui add <url> [tag …]`, `otter-tui login` (validates via `/api/me`, uses `OTTER_BASE_URL`/`OTTER_API_KEY`, writes `~/.config/otter/config.json`).
  - List readability: blank separator line between items; pagination uses 3N − 1 rows.

- **Implementation**
  - No runtime deps; custom ANSI renderer + key parser (alt-screen, 256-color, wide-char aware) with escape-safe sanitization of API text.
  - Pure renderer (`src/ui.ts`) and helpers with 31 unit tests (vitest).
  - TypeScript with `erasableSyntaxOnly` + `rewriteRelativeImportExtensions`; dev via `node src/index.ts` (Node ≥ 22.18), build for Node ≥ 20; root scripts `tui:build`/`tui:dev`.
  - Worker: `/api/search` now supports `star` and `tag` query params for consistent filtered search.

<sup>Written for commit 52f1261e3450a57488ed80e552979bbd39ea98d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/Otter/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

