### PR TITLE
feat(web): import and export bookmarks as Netscape bookmarks.html

### DIFF
--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AppTypeTypeRouteImport } from './routes/_app/type.$type'
 import { Route as AppTagTagRouteImport } from './routes/_app/tag.$tag'
 import { Route as AppSettingsTagsRouteImport } from './routes/_app/settings/tags'
 import { Route as AppSettingsIntegrationsRouteImport } from './routes/_app/settings/integrations'
+import { Route as AppSettingsDataRouteImport } from './routes/_app/settings/data'
 import { Route as AppSettingsAccountRouteImport } from './routes/_app/settings/account'
 import { Route as AppOauthConsentRouteImport } from './routes/_app/oauth/consent'
 import { Route as AppNewBookmarkRouteImport } from './routes/_app/new.bookmark'
@@ -174,6 +175,11 @@ const AppSettingsIntegrationsRoute = AppSettingsIntegrationsRouteImport.update({
   path: '/integrations',
   getParentRoute: () => AppSettingsRouteRoute,
 } as any)
+const AppSettingsDataRoute = AppSettingsDataRouteImport.update({
+  id: '/data',
+  path: '/data',
+  getParentRoute: () => AppSettingsRouteRoute,
+} as any)
 const AppSettingsAccountRoute = AppSettingsAccountRouteImport.update({
   id: '/account',
   path: '/account',
@@ -238,6 +244,7 @@ export interface FileRoutesByFullPath {
   '/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/oauth/consent': typeof AppOauthConsentRoute
   '/settings/account': typeof AppSettingsAccountRoute
+  '/settings/data': typeof AppSettingsDataRoute
   '/settings/integrations': typeof AppSettingsIntegrationsRoute
   '/settings/tags': typeof AppSettingsTagsRoute
   '/tag/$tag': typeof AppTagTagRoute
@@ -272,6 +279,7 @@ export interface FileRoutesByTo {
   '/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/oauth/consent': typeof AppOauthConsentRoute
   '/settings/account': typeof AppSettingsAccountRoute
+  '/settings/data': typeof AppSettingsDataRoute
   '/settings/integrations': typeof AppSettingsIntegrationsRoute
   '/settings/tags': typeof AppSettingsTagsRoute
   '/tag/$tag': typeof AppTagTagRoute
@@ -309,6 +317,7 @@ export interface FileRoutesById {
   '/_app/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/_app/oauth/consent': typeof AppOauthConsentRoute
   '/_app/settings/account': typeof AppSettingsAccountRoute
+  '/_app/settings/data': typeof AppSettingsDataRoute
   '/_app/settings/integrations': typeof AppSettingsIntegrationsRoute
   '/_app/settings/tags': typeof AppSettingsTagsRoute
   '/_app/tag/$tag': typeof AppTagTagRoute
@@ -345,6 +354,7 @@ export interface FileRouteTypes {
     | '/new/bookmark'
     | '/oauth/consent'
     | '/settings/account'
+    | '/settings/data'
     | '/settings/integrations'
     | '/settings/tags'
     | '/tag/$tag'
@@ -379,6 +389,7 @@ export interface FileRouteTypes {
     | '/new/bookmark'
     | '/oauth/consent'
     | '/settings/account'
+    | '/settings/data'
     | '/settings/integrations'
     | '/settings/tags'
     | '/tag/$tag'
@@ -415,6 +426,7 @@ export interface FileRouteTypes {
     | '/_app/new/bookmark'
     | '/_app/oauth/consent'
     | '/_app/settings/account'
+    | '/_app/settings/data'
     | '/_app/settings/integrations'
     | '/_app/settings/tags'
     | '/_app/tag/$tag'
@@ -621,6 +633,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSettingsIntegrationsRouteImport
       parentRoute: typeof AppSettingsRouteRoute
     }
+    '/_app/settings/data': {
+      id: '/_app/settings/data'
+      path: '/data'
+      fullPath: '/settings/data'
+      preLoaderRoute: typeof AppSettingsDataRouteImport
+      parentRoute: typeof AppSettingsRouteRoute
+    }
     '/_app/settings/account': {
       id: '/_app/settings/account'
       path: '/account'
@@ -682,12 +701,14 @@ declare module '@tanstack/react-router' {
 
 interface AppSettingsRouteRouteChildren {
   AppSettingsAccountRoute: typeof AppSettingsAccountRoute
+  AppSettingsDataRoute: typeof AppSettingsDataRoute
   AppSettingsIntegrationsRoute: typeof AppSettingsIntegrationsRoute
   AppSettingsTagsRoute: typeof AppSettingsTagsRoute
 }
 
 const AppSettingsRouteRouteChildren: AppSettingsRouteRouteChildren = {
   AppSettingsAccountRoute: AppSettingsAccountRoute,
+  AppSettingsDataRoute: AppSettingsDataRoute,
   AppSettingsIntegrationsRoute: AppSettingsIntegrationsRoute,
   AppSettingsTagsRoute: AppSettingsTagsRoute,
 }

--- a/packages/web/src/routes/_app/settings/data.tsx
+++ b/packages/web/src/routes/_app/settings/data.tsx
@@ -1,0 +1,112 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { type FormEvent, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/Button'
+import { Label } from '@/components/Label'
+import {
+  type BookmarkImportResult,
+  importBookmarksFile,
+} from '@/utils/fetching/bookmarks'
+import { getErrorMessage } from '@/utils/get-error-message'
+
+export const Route = createFileRoute('/_app/settings/data')({
+  component: RouteComponent,
+  head: () => ({
+    meta: [
+      {
+        title: 'Import & export',
+      },
+    ],
+  }),
+})
+
+function RouteComponent() {
+  const queryClient = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [importing, setImporting] = useState(false)
+  const [result, setResult] = useState<BookmarkImportResult | null>(null)
+
+  const handleImport = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const file = fileInputRef.current?.files?.[0]
+
+    if (!file) {
+      toast.error('Choose a bookmarks HTML file first')
+      return
+    }
+
+    setImporting(true)
+    setResult(null)
+
+    try {
+      const { data } = await importBookmarksFile(file)
+      setResult(data)
+      toast.success(
+        `Imported ${data.imported} bookmark${data.imported === 1 ? '' : 's'}`,
+      )
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
+      queryClient.invalidateQueries({ queryKey: ['meta'] })
+    } catch (error) {
+      toast.error(getErrorMessage(error))
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  return (
+    <article className="flow">
+      <h3>Import bookmarks</h3>
+      <p>
+        Import bookmarks from a <code>bookmarks.html</code> file — the standard
+        export format of Chrome, Firefox, Safari, Edge, Pinboard and most other
+        bookmark managers. Folder names and tags in the file become Otter tags,
+        and bookmarks with a URL you have already saved are skipped.
+      </p>
+      <form onSubmit={handleImport} className="flex flex-col gap-s">
+        <div className="form-group">
+          <Label htmlFor="bookmarksFile" className="mb-1">
+            Bookmarks HTML file
+          </Label>
+          <input
+            ref={fileInputRef}
+            id="bookmarksFile"
+            name="bookmarksFile"
+            type="file"
+            accept=".html,.htm,text/html"
+          />
+        </div>
+        <div>
+          <Button type="submit" disabled={importing}>
+            {importing ? 'Importing…' : 'Import bookmarks'}
+          </Button>
+        </div>
+      </form>
+      {result ? (
+        <output className="block">
+          Found {result.found} bookmark{result.found === 1 ? '' : 's'} in the
+          file: {result.imported} imported, {result.skipped} skipped as already
+          saved.
+        </output>
+      ) : null}
+
+      <h3>Export bookmarks</h3>
+      <p>
+        Download all your active bookmarks as a <code>bookmarks.html</code> file
+        that can be imported into any browser or bookmark manager.
+      </p>
+      <div>
+        <Button asChild>
+          <a href="/api/bookmarks/export" download>
+            Export bookmarks
+          </a>
+        </Button>
+      </div>
+    </article>
+  )
+}

--- a/packages/web/src/routes/_app/settings/route.tsx
+++ b/packages/web/src/routes/_app/settings/route.tsx
@@ -2,6 +2,7 @@ import {
   GearIcon,
   HashIcon,
   PlugsIcon,
+  SwapIcon,
   UserCircleIcon,
 } from '@phosphor-icons/react'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
@@ -42,6 +43,10 @@ function RouteComponent() {
         <SidebarLink href="/settings/tags">
           <HashIcon weight="duotone" size={18} />
           Manage tags
+        </SidebarLink>
+        <SidebarLink href="/settings/data">
+          <SwapIcon weight="duotone" size={18} />
+          Import &amp; export
         </SidebarLink>
       </Flex>
 

--- a/packages/web/src/utils/fetching/bookmarks.ts
+++ b/packages/web/src/utils/fetching/bookmarks.ts
@@ -156,6 +156,25 @@ export const incrementBookmarkClickCount = async (id: string) => {
   return await parseJsonResponse<SingleResponse<Bookmark>>(response)
 }
 
+export type BookmarkImportResult = {
+  found: number
+  imported: number
+  skipped: number
+}
+
+export const importBookmarksFile = async (file: File) => {
+  const body = new FormData()
+  body.append('file', file)
+
+  const response = await fetch('/api/bookmarks/import', {
+    body,
+    credentials: 'include',
+    method: 'POST',
+  })
+
+  return await parseJsonResponse<SingleResponse<BookmarkImportResult>>(response)
+}
+
 export const checkBookmarkUrl = async (urlInput: string) => {
   const response = await fetch(
     `/api/check-url${queryString({ url_input: urlInput })}`,

--- a/packages/web/worker/bookmarks/importExport.ts
+++ b/packages/web/worker/bookmarks/importExport.ts
@@ -1,0 +1,186 @@
+import { and, desc, eq } from 'drizzle-orm'
+import type { Context } from 'hono'
+import { API_HEADERS } from '@/constants'
+import { errorResponse } from '@/utils/fetching/errorResponse'
+import { getErrorMessage } from '@/utils/get-error-message'
+import { bookmarks } from '../../db/schema'
+import { requireRequestContext } from '../context'
+import type { WorkerEnv } from '../env'
+import { parseNetscapeBookmarks, serializeNetscapeBookmarks } from './netscape'
+
+type HonoContext = Context<{ Bindings: WorkerEnv }>
+type BookmarkInsert = typeof bookmarks.$inferInsert
+
+const MAX_IMPORT_BYTES = 25 * 1024 * 1024
+const INSERT_CHUNK_SIZE = 200
+
+const getAuthed = async (context: HonoContext, scopes: string[]) => {
+  const requestContext = await requireRequestContext(context, scopes)
+
+  if (requestContext instanceof Response) {
+    return requestContext
+  }
+
+  const userId = requestContext.user?.id
+
+  if (!userId) {
+    return errorResponse({ reason: 'Not authorised', status: 401 })
+  }
+
+  return { requestContext, userId }
+}
+
+const readImportHtml = async (context: HonoContext) => {
+  const contentType = context.req.header('content-type') ?? ''
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await context.req.formData()
+    const file = formData.get('file')
+
+    if (!(file instanceof File)) {
+      return null
+    }
+
+    if (file.size > MAX_IMPORT_BYTES) {
+      throw new Error('File is too large (max 25MB)')
+    }
+
+    return await file.text()
+  }
+
+  return await context.req.text()
+}
+
+/**
+ * POST /api/bookmarks/import
+ * Imports bookmarks from a Netscape-format `bookmarks.html` file (the
+ * standard export format of Chrome, Firefox, Safari, Pinboard, etc.).
+ * Accepts the file as multipart form-data (`file` field) or as a raw
+ * text/html request body. Bookmarks whose URL already exists for the user
+ * are skipped.
+ */
+export const importBookmarks = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context, ['bookmarks:write'])
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const html = await readImportHtml(context)
+
+    if (!html?.trim()) {
+      return errorResponse({
+        error: 'No file provided',
+        reason: 'Upload a bookmarks HTML file as the `file` form field',
+        status: 400,
+      })
+    }
+
+    const parsed = parseNetscapeBookmarks(html)
+
+    if (parsed.length === 0) {
+      return errorResponse({
+        error: 'No bookmarks found',
+        reason:
+          'The file does not look like a bookmarks HTML export — no bookmarks were found in it',
+        status: 400,
+      })
+    }
+
+    const existing = await auth.requestContext.db
+      .select({ url: bookmarks.url })
+      .from(bookmarks)
+      .where(eq(bookmarks.user, auth.userId))
+    const existingUrls = new Set(existing.map((row) => row.url).filter(Boolean))
+    const toInsert: BookmarkInsert[] = parsed
+      .filter((item) => !existingUrls.has(item.url))
+      .map((item) => ({
+        createdAt: item.createdAt ?? undefined,
+        description: item.description,
+        tags: item.tags.length ? item.tags : null,
+        title: item.title ?? item.url,
+        type: 'link' as const,
+        url: item.url,
+        user: auth.userId,
+      }))
+
+    for (let i = 0; i < toInsert.length; i += INSERT_CHUNK_SIZE) {
+      await auth.requestContext.db
+        .insert(bookmarks)
+        .values(toInsert.slice(i, i + INSERT_CHUNK_SIZE))
+    }
+
+    return new Response(
+      JSON.stringify({
+        data: {
+          found: parsed.length,
+          imported: toInsert.length,
+          skipped: parsed.length - toInsert.length,
+        },
+        error: null,
+      }),
+      {
+        headers: API_HEADERS,
+        status: 200,
+      },
+    )
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem importing bookmarks',
+      status: 400,
+    })
+  }
+}
+
+/**
+ * GET /api/bookmarks/export
+ * Exports all the user's active bookmarks as a Netscape-format
+ * `bookmarks.html` file that browsers and other bookmark managers can import.
+ */
+export const exportBookmarks = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context, ['bookmarks:read'])
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const rows = await auth.requestContext.db
+      .select()
+      .from(bookmarks)
+      .where(
+        and(eq(bookmarks.user, auth.userId), eq(bookmarks.status, 'active')),
+      )
+      .orderBy(desc(bookmarks.createdAt))
+    const html = serializeNetscapeBookmarks(
+      rows
+        .filter((row) => row.url)
+        .map((row) => ({
+          createdAt: row.createdAt,
+          description: row.description,
+          modifiedAt: row.modifiedAt,
+          public: row.public,
+          tags: row.tags,
+          title: row.title,
+          url: row.url as string,
+        })),
+    )
+    const date = new Date().toISOString().slice(0, 10)
+
+    return new Response(html, {
+      headers: {
+        'Content-Disposition': `attachment; filename="otter-bookmarks-${date}.html"`,
+        'Content-Type': 'text/html; charset=utf-8',
+      },
+      status: 200,
+    })
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem exporting bookmarks',
+      status: 400,
+    })
+  }
+}

--- a/packages/web/worker/bookmarks/netscape.test.ts
+++ b/packages/web/worker/bookmarks/netscape.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import { parseNetscapeBookmarks, serializeNetscapeBookmarks } from './netscape'
+
+const chromeExport = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+     It will be read and overwritten.
+     DO NOT EDIT! -->
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><H3 ADD_DATE="1700000000" LAST_MODIFIED="1700000001" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks bar</H3>
+    <DL><p>
+        <DT><A HREF="https://example.com/" ADD_DATE="1700000002" ICON="data:image/png;base64,xyz">Example &amp; Friends</A>
+        <DT><H3 ADD_DATE="1700000003">Dev Tools</H3>
+        <DL><p>
+            <DT><A HREF="https://github.com/" ADD_DATE="1700000004">GitHub</A>
+            <DT><A HREF="https://developer.mozilla.org/" ADD_DATE="1700000005">MDN</A>
+        </DL><p>
+    </DL><p>
+</DL><p>
+`
+
+const pinboardExport = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Pinboard Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><A HREF="https://example.org/article" ADD_DATE="1600000000" PRIVATE="1" TOREAD="0" TAGS="reading,web dev">A Great Article</A>
+<DD>Some notes about the article
+<DT><A HREF="https://example.org/other" ADD_DATE="1600000001" PRIVATE="0" TOREAD="0" TAGS="">Another one</A>
+</DL></p>
+`
+
+describe('parseNetscapeBookmarks', () => {
+  it('parses a Chrome-style nested export, mapping folders to tags', () => {
+    const items = parseNetscapeBookmarks(chromeExport)
+
+    expect(items).toHaveLength(3)
+    expect(items[0]).toEqual({
+      createdAt: new Date(1700000002 * 1000),
+      description: null,
+      tags: [],
+      title: 'Example & Friends',
+      url: 'https://example.com/',
+    })
+    // nested folder becomes a tag; the root "Bookmarks bar" folder does not
+    expect(items[1].url).toBe('https://github.com/')
+    expect(items[1].tags).toEqual(['Dev Tools'])
+    expect(items[2].tags).toEqual(['Dev Tools'])
+  })
+
+  it('parses Pinboard-style exports with TAGS attributes and descriptions', () => {
+    const items = parseNetscapeBookmarks(pinboardExport)
+
+    expect(items).toHaveLength(2)
+    expect(items[0]).toEqual({
+      createdAt: new Date(1600000000 * 1000),
+      description: 'Some notes about the article',
+      tags: ['reading', 'web dev'],
+      title: 'A Great Article',
+      url: 'https://example.org/article',
+    })
+    expect(items[1].description).toBeNull()
+    expect(items[1].tags).toEqual([])
+  })
+
+  it('skips non-web protocols and duplicate urls', () => {
+    const items = parseNetscapeBookmarks(`
+      <DL><p>
+        <DT><A HREF="javascript:alert(1)">Bookmarklet</A>
+        <DT><A HREF="place:type=6">Firefox internal</A>
+        <DT><A HREF="https://example.com/">First</A>
+        <DT><A HREF="https://example.com/">Duplicate</A>
+      </DL><p>
+    `)
+
+    expect(items).toHaveLength(1)
+    expect(items[0].title).toBe('First')
+  })
+
+  it('handles missing ADD_DATE, attribute-less anchors and entities', () => {
+    const items = parseNetscapeBookmarks(`
+      <DL><p>
+        <DT><A HREF="https://example.com/?a=1&amp;b=2" ADD_DATE="">Caf&eacute;&#233; &quot;quoted&quot;</A>
+      </DL><p>
+    `)
+
+    expect(items).toHaveLength(1)
+    expect(items[0].url).toBe('https://example.com/?a=1&b=2')
+    // unknown named entities are left as-is, numeric ones are decoded
+    expect(items[0].title).toBe('Caf&eacute;é "quoted"')
+    expect(items[0].createdAt).toBeNull()
+  })
+
+  it('normalises millisecond and microsecond timestamps', () => {
+    const items = parseNetscapeBookmarks(`
+      <DL><p>
+        <DT><A HREF="https://a.com/" ADD_DATE="1700000000000">ms</A>
+        <DT><A HREF="https://b.com/" ADD_DATE="1700000000000000">µs</A>
+      </DL><p>
+    `)
+
+    expect(items[0].createdAt).toEqual(new Date(1700000000 * 1000))
+    expect(items[1].createdAt).toEqual(new Date(1700000000 * 1000))
+  })
+
+  it('returns an empty array for content with no bookmarks', () => {
+    expect(parseNetscapeBookmarks('<html><body>hello</body></html>')).toEqual(
+      [],
+    )
+  })
+})
+
+describe('serializeNetscapeBookmarks', () => {
+  it('produces a Netscape file that round-trips through the parser', () => {
+    const createdAt = new Date(1700000000 * 1000)
+    const html = serializeNetscapeBookmarks([
+      {
+        createdAt,
+        description: 'Notes with <angle> & "quotes"',
+        modifiedAt: createdAt,
+        public: false,
+        tags: ['reading', 'web dev'],
+        title: 'Example & Friends',
+        url: 'https://example.com/?a=1&b=2',
+      },
+      {
+        createdAt,
+        description: null,
+        modifiedAt: createdAt,
+        public: true,
+        tags: null,
+        title: null,
+        url: 'https://no-title.com/',
+      },
+    ])
+
+    expect(html).toContain('<!DOCTYPE NETSCAPE-Bookmark-file-1>')
+    expect(html).toContain('PRIVATE="1"')
+    expect(html).toContain('PRIVATE="0"')
+
+    const items = parseNetscapeBookmarks(html)
+
+    expect(items).toHaveLength(2)
+    expect(items[0]).toEqual({
+      createdAt,
+      description: 'Notes with <angle> & "quotes"',
+      tags: ['reading', 'web dev'],
+      title: 'Example & Friends',
+      url: 'https://example.com/?a=1&b=2',
+    })
+    // bookmarks without a title fall back to the url
+    expect(items[1].title).toBe('https://no-title.com/')
+  })
+})

--- a/packages/web/worker/bookmarks/netscape.ts
+++ b/packages/web/worker/bookmarks/netscape.ts
@@ -1,0 +1,220 @@
+/**
+ * Parse and serialize the Netscape bookmark file format (`bookmarks.html`) —
+ * the de-facto import/export format used by Chrome, Firefox, Safari,
+ * Pinboard, et al.
+ *
+ * The format is intentionally malformed HTML (unclosed <DT>/<DD> tags), so
+ * this is a tolerant token-based parser rather than a DOM walk.
+ */
+
+export type ParsedNetscapeBookmark = {
+  url: string
+  title: string | null
+  description: string | null
+  tags: string[]
+  createdAt: Date | null
+}
+
+export type ExportableBookmark = {
+  url: string
+  title: string | null
+  description: string | null
+  tags: string[] | null
+  createdAt: Date
+  modifiedAt: Date
+  public: boolean
+}
+
+// Browser root folders that carry no meaning as tags
+const ROOT_FOLDER_NAMES = new Set([
+  'bookmarks',
+  'bookmarks bar',
+  'bookmarks menu',
+  'bookmarks toolbar',
+  'favorites',
+  'favorites bar',
+  'imported',
+  'mobile bookmarks',
+  'other bookmarks',
+  'unsorted bookmarks',
+])
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  nbsp: ' ',
+  quot: '"',
+}
+
+export const decodeEntities = (value: string) =>
+  value.replace(
+    /&(?:#x([0-9a-f]+)|#(\d+)|([a-z]+));/gi,
+    (match, hex, dec, named) => {
+      if (hex) return String.fromCodePoint(Number.parseInt(hex, 16))
+      if (dec) return String.fromCodePoint(Number.parseInt(dec, 10))
+      const entity = NAMED_ENTITIES[(named as string).toLowerCase()]
+      return entity ?? match
+    },
+  )
+
+export const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+
+const parseAttributes = (raw: string) => {
+  const attributes: Record<string, string> = {}
+
+  for (const match of raw.matchAll(/([\w-]+)\s*=\s*"([^"]*)"/g)) {
+    attributes[match[1].toLowerCase()] = decodeEntities(match[2])
+  }
+
+  return attributes
+}
+
+// ADD_DATE is unix seconds, but some exporters use ms or µs
+const parseTimestamp = (value: string | undefined) => {
+  if (!value) return null
+
+  let timestamp = Number.parseInt(value, 10)
+
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return null
+  if (timestamp > 1e15) timestamp = Math.floor(timestamp / 1e6)
+  else if (timestamp > 1e12) timestamp = Math.floor(timestamp / 1e3)
+
+  const date = new Date(timestamp * 1000)
+
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+const cleanText = (value: string) =>
+  decodeEntities(value.replace(/<[^>]*>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const SKIPPED_PROTOCOLS = /^(?:javascript|place|data|about|chrome|file):/i
+
+const TOKEN_PATTERN =
+  /<DT[^>]*>\s*<H3([^>]*)>([\s\S]*?)<\/H3>|<DT[^>]*>\s*<A([^>]*)>([\s\S]*?)<\/A>|<DL[^>]*>|<\/DL>|<DD[^>]*>([\s\S]*?)(?=<DT|<DL|<\/DL|<DD|<HR|$)/gi
+
+export const parseNetscapeBookmarks = (
+  html: string,
+): ParsedNetscapeBookmark[] => {
+  const items: ParsedNetscapeBookmark[] = []
+  const seenUrls = new Set<string>()
+  const folderStack: string[] = []
+  let pendingFolder: string | null = null
+  let lastItem: ParsedNetscapeBookmark | null = null
+
+  for (const match of html.matchAll(TOKEN_PATTERN)) {
+    const [token, h3Attrs, h3Text, aAttrs, aText, ddText] = match
+
+    if (h3Attrs !== undefined) {
+      pendingFolder = cleanText(h3Text)
+      continue
+    }
+
+    if (/^<DL/i.test(token)) {
+      folderStack.push(pendingFolder ?? '')
+      pendingFolder = null
+      continue
+    }
+
+    if (/^<\/DL/i.test(token)) {
+      folderStack.pop()
+      continue
+    }
+
+    if (aAttrs !== undefined) {
+      const attributes = parseAttributes(aAttrs)
+      const url = attributes.href?.trim()
+
+      lastItem = null
+
+      if (!url || SKIPPED_PROTOCOLS.test(url) || seenUrls.has(url)) {
+        continue
+      }
+
+      const tags = new Set<string>()
+
+      for (const tag of (attributes.tags ?? '').split(',')) {
+        const trimmed = tag.trim()
+        if (trimmed) tags.add(trimmed)
+      }
+
+      for (const folder of folderStack) {
+        const trimmed = folder.trim()
+        if (trimmed && !ROOT_FOLDER_NAMES.has(trimmed.toLowerCase())) {
+          tags.add(trimmed)
+        }
+      }
+
+      const title = cleanText(aText)
+      const item: ParsedNetscapeBookmark = {
+        createdAt: parseTimestamp(attributes.add_date),
+        description: null,
+        tags: [...tags],
+        title: title || null,
+        url,
+      }
+
+      seenUrls.add(url)
+      items.push(item)
+      lastItem = item
+      continue
+    }
+
+    if (ddText !== undefined && lastItem && !lastItem.description) {
+      const description = cleanText(ddText)
+      if (description) lastItem.description = description
+    }
+  }
+
+  return items
+}
+
+const toUnixSeconds = (date: Date) => Math.floor(date.getTime() / 1000)
+
+export const serializeNetscapeBookmarks = (
+  items: ExportableBookmark[],
+): string => {
+  const lines = [
+    '<!DOCTYPE NETSCAPE-Bookmark-file-1>',
+    '<!-- This is an automatically generated file.',
+    '     It will be read and overwritten.',
+    '     DO NOT EDIT! -->',
+    '<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">',
+    '<TITLE>Bookmarks</TITLE>',
+    '<H1>Bookmarks</H1>',
+    '<DL><p>',
+  ]
+
+  for (const item of items) {
+    const attributes = [
+      `HREF="${escapeHtml(item.url)}"`,
+      `ADD_DATE="${toUnixSeconds(item.createdAt)}"`,
+      `LAST_MODIFIED="${toUnixSeconds(item.modifiedAt)}"`,
+      `PRIVATE="${item.public ? '0' : '1'}"`,
+    ]
+
+    if (item.tags?.length) {
+      attributes.push(`TAGS="${escapeHtml(item.tags.join(','))}"`)
+    }
+
+    lines.push(
+      `    <DT><A ${attributes.join(' ')}>${escapeHtml(item.title || item.url)}</A>`,
+    )
+
+    if (item.description) {
+      lines.push(`    <DD>${escapeHtml(item.description)}`)
+    }
+  }
+
+  lines.push('</DL><p>', '')
+
+  return lines.join('\n')
+}

--- a/packages/web/worker/hono.ts
+++ b/packages/web/worker/hono.ts
@@ -9,6 +9,7 @@ import { titleSystemPrompt } from './ai/title'
 import { sendBlueskyPost } from './bluesky/sendBlueskyPost'
 import { getAllBookmarks } from './bookmarks/getAllBookmarks'
 import { getRecentPublicBookmarks } from './bookmarks/getRecentPublicBookmarks'
+import { exportBookmarks, importBookmarks } from './bookmarks/importExport'
 import {
   checkBookmarkUrl,
   createBookmark,
@@ -48,15 +49,15 @@ import {
 } from './meta'
 import { dbMiddleware } from './middleware/db'
 import { getCurrentProfile, updateCurrentProfile } from './profile'
+import { feedToJson } from './rss/rss-to-json'
+import { handleScrapeContent } from './scraper/scrape-content'
+import { getSearch } from './search/search'
 import {
   createOrRotateShare,
   deleteShare,
   getPublicShare,
   listShares,
 } from './shares'
-import { feedToJson } from './rss/rss-to-json'
-import { handleScrapeContent } from './scraper/scrape-content'
-import { getSearch } from './search/search'
 import {
   getToot,
   getToots,
@@ -166,6 +167,12 @@ api.get('/bookmarks', async (c) => {
 })
 api.post('/bookmarks', async (c) => {
   return await createBookmark(c)
+})
+api.post('/bookmarks/import', async (c) => {
+  return await importBookmarks(c)
+})
+api.get('/bookmarks/export', async (c) => {
+  return await exportBookmarks(c)
 })
 api.get('/bookmarks/:id', async (c) => {
   return await getBookmarkById(c)


### PR DESCRIPTION
## Summary

Adds mass import and export of bookmarks via the standard Netscape `bookmarks.html` format — the export/import format used by Chrome, Firefox, Safari, Edge, Pinboard and most other bookmark managers. Useful for new users migrating into Otter, and for getting data back out.

### API

- **`POST /api/bookmarks/import`** — accepts a `bookmarks.html` file as multipart form-data (`file` field) or a raw HTML body. Parses the file, inserts the bookmarks for the authenticated user (chunked inserts), and returns `{ found, imported, skipped }`.
  - Folder names become Otter tags (browser root folders like "Bookmarks bar" are excluded), and Pinboard-style `TAGS` attributes are honoured.
  - `ADD_DATE` timestamps are preserved as `created_at` (handles seconds, ms and µs variants).
  - `<DD>` descriptions are imported.
  - URLs the user has already saved are skipped, as are duplicates within the file and non-web protocols (`javascript:`, `place:`, etc.).
- **`GET /api/bookmarks/export`** — downloads all the user's active bookmarks as a Netscape-format file (with `TAGS` and `PRIVATE` attributes) named `otter-bookmarks-<date>.html`.

Both endpoints use the existing auth context (session cookie, OAuth bearer token with `bookmarks:write`/`bookmarks:read` scopes, or API key), so the import can also be driven from the command line:

```sh
curl -F file=@bookmarks.html "https://your-otter/api/bookmarks/import?api_key=…"
```

### UI

New **Import &amp; export** page under Settings (`/settings/data`) with a file-upload import form (shows an imported/skipped summary and invalidates bookmark queries) and an export download button.

### Implementation notes

- The Netscape format is intentionally malformed HTML (unclosed `<DT>`/`<DD>`), so parsing uses a tolerant token-based parser (`worker/bookmarks/netscape.ts`) rather than a DOM walk — covered by round-trip unit tests against Chrome-style and Pinboard-style fixtures.
- `tsc -b`, `vite build`, biome and `pnpm vitest run worker/bookmarks` all pass.

https://claude.ai/code/session_01Ddd7wmBxibMQddSHTEMwEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ddd7wmBxibMQddSHTEMwEp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add import and export of bookmarks using the Netscape `bookmarks.html` format used by Chrome, Firefox, Safari, Edge, and Pinboard. This helps new users migrate in and lets anyone export their data.

- **New Features**
  - `POST /api/bookmarks/import`: accepts a `bookmarks.html` file (multipart `file` field or raw HTML). Parses Netscape format, maps folders and `TAGS` to Otter tags, preserves `ADD_DATE`, imports `<DD>` descriptions, and skips duplicates and non-web protocols. Returns `{ found, imported, skipped }`. Size limit: 25 MB.
  - `GET /api/bookmarks/export`: downloads all active bookmarks as Netscape-format HTML (includes `TAGS` and `PRIVATE`), named `otter-bookmarks-<date>.html`.
  - Auth: uses existing session/OAuth (scopes `bookmarks:write`/`bookmarks:read`) or API key.
  - UI: new Import & export page at `/settings/data` with upload form, result summary, and an export button. Invalidates bookmark queries after import.
  - Parser: tolerant token-based Netscape parser with round-trip tests.

<sup>Written for commit c810601ac684c940fac7087b937a4a39c96d866c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/Otter/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

