### PR TITLE
feat(web): platform-agnostic feeds for external saves (Bluesky, GitHub, YouTube)

### DIFF
--- a/packages/web/db/schema.ts
+++ b/packages/web/db/schema.ts
@@ -481,6 +481,66 @@ export const shares = pgTable(
   ],
 )
 
+export const platformConnections = pgTable(
+  'platform_connections',
+  {
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    credentials: json('credentials').notNull(),
+    enabled: boolean('enabled').notNull().default(true),
+    id: uuid('id').primaryKey().defaultRandom(),
+    lastError: text('last_error'),
+    lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
+    platform: text('platform').notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+  },
+  (table) => [
+    uniqueIndex('platform_connections_user_platform_key').on(
+      table.userId,
+      table.platform,
+    ),
+    index('platform_connections_user_id_idx').on(table.userId),
+  ],
+)
+
+export const platformItems = pgTable(
+  'platform_items',
+  {
+    bookmarkId: uuid('bookmark_id').references(() => bookmarks.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    description: text('description'),
+    externalId: text('external_id').notNull(),
+    id: uuid('id').primaryKey().defaultRandom(),
+    image: text('image'),
+    ingestedAt: timestamp('ingested_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    metadata: json('metadata'),
+    platform: text('platform').notNull(),
+    title: text('title'),
+    url: text('url'),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+  },
+  (table) => [
+    uniqueIndex('platform_items_user_platform_external_key').on(
+      table.userId,
+      table.platform,
+      table.externalId,
+    ),
+    index('platform_items_user_platform_idx').on(table.userId, table.platform),
+  ],
+)
+
 export const userIntegrations = pgTable('user_integrations', {
   blueskyAppPassword: text('bluesky_app_password'),
   blueskyEnabled: boolean('bluesky_enabled').notNull().default(false),

--- a/packages/web/drizzle/0002_platform_feeds.sql
+++ b/packages/web/drizzle/0002_platform_feeds.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "platform_connections" (
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"credentials" json NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"last_error" text,
+	"last_synced_at" timestamp with time zone,
+	"platform" text NOT NULL,
+	"updated_at" timestamp with time zone,
+	"user_id" uuid NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "platform_items" (
+	"bookmark_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"description" text,
+	"external_id" text NOT NULL,
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"image" text,
+	"ingested_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" json,
+	"platform" text NOT NULL,
+	"title" text,
+	"url" text,
+	"user_id" uuid NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "platform_connections" ADD CONSTRAINT "platform_connections_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "platform_items" ADD CONSTRAINT "platform_items_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "platform_items" ADD CONSTRAINT "platform_items_bookmark_id_bookmarks_id_fk" FOREIGN KEY ("bookmark_id") REFERENCES "public"."bookmarks"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "platform_connections_user_platform_key" ON "platform_connections" USING btree ("user_id","platform");--> statement-breakpoint
+CREATE INDEX "platform_connections_user_id_idx" ON "platform_connections" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "platform_items_user_platform_external_key" ON "platform_items" USING btree ("user_id","platform","external_id");--> statement-breakpoint
+CREATE INDEX "platform_items_user_platform_idx" ON "platform_items" USING btree ("user_id","platform");

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -14,6 +14,13 @@
       "tag": "0001_shares",
       "version": "7",
       "when": 1778500000000
+    },
+    {
+      "breakpoints": true,
+      "idx": 2,
+      "tag": "0002_platform_feeds",
+      "version": "7",
+      "when": 1781100000000
     }
   ],
   "version": "7"

--- a/packages/web/src/components/Feed.tsx
+++ b/packages/web/src/components/Feed.tsx
@@ -10,12 +10,13 @@ import { type FeedItemModel, useGroupByDate } from '@/hooks/useGroupByDate'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { getCollectionsTagsOptions } from '@/utils/fetching/collections'
 import type { ShareKind } from '@/utils/fetching/shares'
-import type { Bookmark, Toot, Tweet } from '../types/db'
+import type { Bookmark, PlatformItem, Toot, Tweet } from '../types/db'
 import { cn } from '../utils/classnames'
 import { BookmarkFeedItem } from './BookmarkFeedItem'
 import { Flex } from './Flex'
 import { headingVariants } from './Heading'
 import { Loader } from './Loader'
+import { PlatformItemCard } from './PlatformItemCard'
 import { ShareDialog } from './ShareDialog'
 import { SidebarLink } from './SidebarLink'
 import { TootFeedItem } from './TootFeedItem'
@@ -35,7 +36,7 @@ interface FeedProps {
   count: number
   limit?: number
   allowGroupByDate?: boolean
-  feedType?: 'tweets' | 'bookmarks' | 'toots'
+  feedType?: 'tweets' | 'bookmarks' | 'toots' | 'platformItems'
   showFeedOptions?: boolean
   from?: FileRouteTypes['fullPaths']
   hasNextPage?: boolean
@@ -52,6 +53,9 @@ export function isTweet(item: FeedItemModel): item is Tweet {
 }
 export function isToot(item: FeedItemModel): item is Toot {
   return 'toot_id' in item
+}
+export function isPlatformItem(item: FeedItemModel): item is PlatformItem {
+  return 'external_id' in item
 }
 
 export const Feed = memo(
@@ -180,6 +184,8 @@ export const Feed = memo(
                           return <TweetFeedItem {...item} key={item.id} />
                         } else if (isToot(item)) {
                           return <TootFeedItem {...item} key={item.id} />
+                        } else if (isPlatformItem(item)) {
+                          return <PlatformItemCard {...item} key={item.id} />
                         }
                         return (
                           <BookmarkFeedItem
@@ -209,6 +215,8 @@ export const Feed = memo(
                   return <TweetFeedItem {...item} key={item.id} />
                 } else if (isToot(item)) {
                   return <TootFeedItem {...item} key={item.id} />
+                } else if (isPlatformItem(item)) {
+                  return <PlatformItemCard {...item} key={item.id} />
                 }
                 return (
                   <BookmarkFeedItem

--- a/packages/web/src/components/FeedSimple.tsx
+++ b/packages/web/src/components/FeedSimple.tsx
@@ -3,8 +3,9 @@ import { ErrorBoundary } from 'react-error-boundary'
 import type { FeedItemModel } from '../hooks/useGroupByDate'
 import { cn } from '../utils/classnames'
 import { BookmarkFeedItem } from './BookmarkFeedItem'
-import { isToot, isTweet } from './Feed'
+import { isPlatformItem, isToot, isTweet } from './Feed'
 import { headingVariants } from './Heading'
+import { PlatformItemCard } from './PlatformItemCard'
 import { TootFeedItem } from './TootFeedItem'
 import { TweetFeedItem } from './TweetFeedItem'
 
@@ -40,6 +41,8 @@ export const FeedSimple = memo(({ title, icon, items }: FeedSimpleProps) => {
             return <TweetFeedItem {...item} key={item.id} />
           } else if (isToot(item)) {
             return <TootFeedItem {...item} key={item.id} />
+          } else if (isPlatformItem(item)) {
+            return <PlatformItemCard {...item} key={item.id} />
           }
           return (
             <ErrorBoundary

--- a/packages/web/src/components/PlatformIcon.tsx
+++ b/packages/web/src/components/PlatformIcon.tsx
@@ -1,0 +1,23 @@
+import {
+  ButterflyIcon,
+  GithubLogoIcon,
+  type IconProps,
+  PlugsConnectedIcon,
+  YoutubeLogoIcon,
+} from '@phosphor-icons/react'
+import type { PlatformId } from '@/platforms/catalog'
+
+const icons: Record<PlatformId, React.ComponentType<IconProps>> = {
+  bluesky: ButterflyIcon,
+  github: GithubLogoIcon,
+  youtube: YoutubeLogoIcon,
+}
+
+interface PlatformIconProps extends IconProps {
+  platform: string
+}
+
+export const PlatformIcon = ({ platform, ...rest }: PlatformIconProps) => {
+  const Icon = icons[platform as PlatformId] ?? PlugsConnectedIcon
+  return <Icon weight="duotone" {...rest} />
+}

--- a/packages/web/src/components/PlatformItemCard.tsx
+++ b/packages/web/src/components/PlatformItemCard.tsx
@@ -1,0 +1,100 @@
+import {
+  CheckCircleIcon,
+  LinkSimpleHorizontalIcon,
+  PlusCircleIcon,
+} from '@phosphor-icons/react'
+import { isPlatformId, PLATFORMS } from '@/platforms/catalog'
+import type { PlatformItem, PlatformItemAuthor } from '@/types/db'
+import { useConvertPlatformItemMutation } from '@/utils/fetching/platforms'
+import { simpleUrl } from '../utils/simpleUrl'
+import { Button } from './Button'
+import { Flex } from './Flex'
+import { Link } from './Link'
+
+export const PlatformItemCard = (props: PlatformItem) => {
+  const {
+    bookmark_id,
+    description,
+    id,
+    image,
+    metadata,
+    platform,
+    title,
+    url,
+  } = props
+  const convertMutation = useConvertPlatformItemMutation()
+  const definition = isPlatformId(platform) ? PLATFORMS[platform] : null
+  const author = (metadata as { author?: PlatformItemAuthor } | null)?.author
+  const showThumbnail = Boolean(image) && !author
+
+  return (
+    <div className="card feed-item">
+      {author ? (
+        <div className="flex items-center gap-xs">
+          {author.avatar ? (
+            <img src={author.avatar} alt="" className="feed-avatar" />
+          ) : null}
+          <Flex direction="column">
+            <div className="text-step--1">
+              {author.displayName ?? author.handle}
+            </div>
+            <div className="text-step--2">@{author.handle}</div>
+          </Flex>
+        </div>
+      ) : null}
+
+      <div className="feed-item-cols">
+        <div className="feed-item-content">
+          {title ? (
+            url ? (
+              <Link rel="external" href={url} className="text-step-0">
+                {title}
+              </Link>
+            ) : (
+              <div className="text-step-0">{title}</div>
+            )
+          ) : null}
+          {description ? (
+            <p className="line-clamp-4 text-step--1">{description}</p>
+          ) : null}
+        </div>
+        {showThumbnail && image ? (
+          <img src={image} alt="" className="max-w-full rounded-md" />
+        ) : null}
+      </div>
+
+      <Flex gap="xs" align="center" wrap="wrap">
+        <Button
+          size="xs"
+          variant="ghost"
+          disabled={Boolean(bookmark_id) || convertMutation.isPending}
+          onClick={() => {
+            if (isPlatformId(platform)) {
+              convertMutation.mutate({ id, platform })
+            }
+          }}
+        >
+          {bookmark_id ? (
+            <>
+              <CheckCircleIcon weight="duotone" size={14} /> Bookmarked
+            </>
+          ) : (
+            <>
+              <PlusCircleIcon weight="duotone" size={14} /> Add bookmark
+            </>
+          )}
+        </Button>
+        {url ? (
+          <Link
+            rel="external"
+            href={url}
+            className="flex items-center gap-2xs text-step--1"
+          >
+            <LinkSimpleHorizontalIcon weight="duotone" size="14" />{' '}
+            {definition ? definition.name : simpleUrl(url)}
+          </Link>
+        ) : null}
+      </Flex>
+    </div>
+  )
+}

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -29,6 +29,7 @@ import {
   ROUTE_TRASH,
   ROUTE_TWEETS_MINE,
 } from '@/constants'
+import { isPlatformId, PLATFORMS } from '@/platforms/catalog'
 import { getMetaOptions } from '@/utils/fetching/meta'
 import { useSidebar } from '../hooks/useSidebar'
 import { CollectionList } from './CollectionList'
@@ -36,6 +37,7 @@ import { Flex } from './Flex'
 import { Link } from './Link'
 import LogoutButton from './LogoutButton'
 import { MastodonLogo } from './MastodonLogo'
+import { PlatformIcon } from './PlatformIcon'
 import { SidebarLink } from './SidebarLink'
 import { Spinner } from './Spinner'
 import { AllTags } from './TagList'
@@ -112,6 +114,23 @@ export const Sidebar = ({ version }: SidebarProps) => {
             <TwitterLogoIcon size={18} weight="duotone" />
             {CONTENT.tweetsNav}
           </SidebarLink>
+          {dbMeta?.platforms?.map(({ platform, count }) =>
+            isPlatformId(platform) ? (
+              <SidebarLink
+                href={`/platform/${platform}`}
+                activePath={`/platform/${platform}`}
+                count={count}
+                key={platform}
+              >
+                <PlatformIcon
+                  platform={platform}
+                  aria-label={PLATFORMS[platform].title}
+                  size={18}
+                />
+                {PLATFORMS[platform].title}
+              </SidebarLink>
+            ) : null,
+          )}
           <TypeList types={dbMeta?.types} />
           <AllTags tags={dbMeta?.tags} />
           <CollectionList

--- a/packages/web/src/hooks/useGroupByDate.ts
+++ b/packages/web/src/hooks/useGroupByDate.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react'
 
 import { useUser } from '../components/UserProvider'
-import type { Bookmark, Toot, Tweet } from '../types/db'
+import type { Bookmark, PlatformItem, Toot, Tweet } from '../types/db'
 
-export type FeedItemModel = Tweet | Bookmark | Toot
+export type FeedItemModel = Tweet | Bookmark | Toot | PlatformItem
 export const groupItemsByDate = (items: FeedItemModel[] = []) => {
   const groupedItems = items.reduce<Record<string, FeedItemModel[]>>(
     (acc, item) => {

--- a/packages/web/src/platforms/catalog.ts
+++ b/packages/web/src/platforms/catalog.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared, platform-agnostic catalog of external platforms that Otter can
+ * sync saved items from (Bluesky bookmarks, GitHub stars, YouTube likes…).
+ *
+ * This module is pure data so it can be imported from both the Worker
+ * (sync + API) and the SPA (generated settings forms, feed pages, sidebar).
+ * To add a new platform: add an entry here, then register a fetcher for the
+ * same id in `worker/platforms/registry.ts`.
+ */
+
+export interface PlatformCredentialField {
+  key: string
+  label: string
+  note?: string
+  placeholder?: string
+  type: 'text' | 'password'
+}
+
+export interface PlatformDefinition {
+  /** Fields the user must provide to connect — drives the generated settings form */
+  credentialFields: PlatformCredentialField[]
+  /** Short explanation shown in the settings UI */
+  description: string
+  helpUrl?: string
+  id: string
+  /** What a single synced item is called, e.g. 'bookmark', 'starred repo' */
+  itemName: string
+  /** Platform name, e.g. 'Bluesky' */
+  name: string
+  /** Feed page + sidebar title, e.g. 'Bluesky bookmarks' */
+  title: string
+}
+
+export const PLATFORMS = {
+  bluesky: {
+    credentialFields: [
+      {
+        key: 'handle',
+        label: 'Handle',
+        placeholder: 'yourname.bsky.social',
+        type: 'text',
+      },
+      {
+        key: 'appPassword',
+        label: 'App Password',
+        note: 'Create one at bsky.app/settings/app-passwords',
+        placeholder: 'xxxx-xxxx-xxxx-xxxx',
+        type: 'password',
+      },
+    ],
+    description: 'Sync the posts you have saved with Bluesky bookmarks.',
+    helpUrl: 'https://bsky.app/settings/app-passwords',
+    id: 'bluesky',
+    itemName: 'bookmark',
+    name: 'Bluesky',
+    title: 'Bluesky bookmarks',
+  },
+  github: {
+    credentialFields: [
+      {
+        key: 'token',
+        label: 'Personal access token',
+        note: 'Fine-grained or classic token with read access to your starred repos',
+        placeholder: 'ghp_…',
+        type: 'password',
+      },
+    ],
+    description: 'Sync the repositories you have starred on GitHub.',
+    helpUrl: 'https://github.com/settings/tokens',
+    id: 'github',
+    itemName: 'starred repo',
+    name: 'GitHub',
+    title: 'GitHub stars',
+  },
+  youtube: {
+    credentialFields: [
+      {
+        key: 'clientId',
+        label: 'OAuth client ID',
+        type: 'text',
+      },
+      {
+        key: 'clientSecret',
+        label: 'OAuth client secret',
+        type: 'password',
+      },
+      {
+        key: 'refreshToken',
+        label: 'Refresh token',
+        note: 'OAuth refresh token authorised with the youtube.readonly scope',
+        type: 'password',
+      },
+    ],
+    description: 'Sync the videos you have liked on YouTube.',
+    helpUrl:
+      'https://developers.google.com/youtube/v3/guides/auth/installed-apps',
+    id: 'youtube',
+    itemName: 'liked video',
+    name: 'YouTube',
+    title: 'YouTube likes',
+  },
+} as const satisfies Record<string, PlatformDefinition>
+
+export type PlatformId = keyof typeof PLATFORMS
+
+export const PLATFORM_IDS = Object.keys(PLATFORMS) as PlatformId[]
+
+export const isPlatformId = (value: string): value is PlatformId =>
+  value in PLATFORMS
+
+export const getPlatform = (id: PlatformId): PlatformDefinition => PLATFORMS[id]

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as AppTagTagRouteImport } from './routes/_app/tag.$tag'
 import { Route as AppSettingsTagsRouteImport } from './routes/_app/settings/tags'
 import { Route as AppSettingsIntegrationsRouteImport } from './routes/_app/settings/integrations'
 import { Route as AppSettingsAccountRouteImport } from './routes/_app/settings/account'
+import { Route as AppPlatformPlatformRouteImport } from './routes/_app/platform.$platform'
 import { Route as AppOauthConsentRouteImport } from './routes/_app/oauth/consent'
 import { Route as AppNewBookmarkRouteImport } from './routes/_app/new.bookmark'
 import { Route as AppCollectionCollectionRouteImport } from './routes/_app/collection.$collection'
@@ -179,6 +180,11 @@ const AppSettingsAccountRoute = AppSettingsAccountRouteImport.update({
   path: '/account',
   getParentRoute: () => AppSettingsRouteRoute,
 } as any)
+const AppPlatformPlatformRoute = AppPlatformPlatformRouteImport.update({
+  id: '/platform/$platform',
+  path: '/platform/$platform',
+  getParentRoute: () => AppRouteRoute,
+} as any)
 const AppOauthConsentRoute = AppOauthConsentRouteImport.update({
   id: '/oauth/consent',
   path: '/oauth/consent',
@@ -237,6 +243,7 @@ export interface FileRoutesByFullPath {
   '/collection/$collection': typeof AppCollectionCollectionRoute
   '/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/oauth/consent': typeof AppOauthConsentRoute
+  '/platform/$platform': typeof AppPlatformPlatformRoute
   '/settings/account': typeof AppSettingsAccountRoute
   '/settings/integrations': typeof AppSettingsIntegrationsRoute
   '/settings/tags': typeof AppSettingsTagsRoute
@@ -271,6 +278,7 @@ export interface FileRoutesByTo {
   '/collection/$collection': typeof AppCollectionCollectionRoute
   '/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/oauth/consent': typeof AppOauthConsentRoute
+  '/platform/$platform': typeof AppPlatformPlatformRoute
   '/settings/account': typeof AppSettingsAccountRoute
   '/settings/integrations': typeof AppSettingsIntegrationsRoute
   '/settings/tags': typeof AppSettingsTagsRoute
@@ -308,6 +316,7 @@ export interface FileRoutesById {
   '/_app/collection/$collection': typeof AppCollectionCollectionRoute
   '/_app/new/bookmark': typeof AppNewBookmarkRouteWithChildren
   '/_app/oauth/consent': typeof AppOauthConsentRoute
+  '/_app/platform/$platform': typeof AppPlatformPlatformRoute
   '/_app/settings/account': typeof AppSettingsAccountRoute
   '/_app/settings/integrations': typeof AppSettingsIntegrationsRoute
   '/_app/settings/tags': typeof AppSettingsTagsRoute
@@ -344,6 +353,7 @@ export interface FileRouteTypes {
     | '/collection/$collection'
     | '/new/bookmark'
     | '/oauth/consent'
+    | '/platform/$platform'
     | '/settings/account'
     | '/settings/integrations'
     | '/settings/tags'
@@ -378,6 +388,7 @@ export interface FileRouteTypes {
     | '/collection/$collection'
     | '/new/bookmark'
     | '/oauth/consent'
+    | '/platform/$platform'
     | '/settings/account'
     | '/settings/integrations'
     | '/settings/tags'
@@ -414,6 +425,7 @@ export interface FileRouteTypes {
     | '/_app/collection/$collection'
     | '/_app/new/bookmark'
     | '/_app/oauth/consent'
+    | '/_app/platform/$platform'
     | '/_app/settings/account'
     | '/_app/settings/integrations'
     | '/_app/settings/tags'
@@ -628,6 +640,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSettingsAccountRouteImport
       parentRoute: typeof AppSettingsRouteRoute
     }
+    '/_app/platform/$platform': {
+      id: '/_app/platform/$platform'
+      path: '/platform/$platform'
+      fullPath: '/platform/$platform'
+      preLoaderRoute: typeof AppPlatformPlatformRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
     '/_app/oauth/consent': {
       id: '/_app/oauth/consent'
       path: '/oauth/consent'
@@ -737,6 +756,7 @@ interface AppRouteRouteChildren {
   AppCollectionCollectionRoute: typeof AppCollectionCollectionRoute
   AppNewBookmarkRoute: typeof AppNewBookmarkRouteWithChildren
   AppOauthConsentRoute: typeof AppOauthConsentRoute
+  AppPlatformPlatformRoute: typeof AppPlatformPlatformRoute
   AppTagTagRoute: typeof AppTagTagRoute
   AppTypeTypeRoute: typeof AppTypeTypeRoute
 }
@@ -757,6 +777,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppCollectionCollectionRoute: AppCollectionCollectionRoute,
   AppNewBookmarkRoute: AppNewBookmarkRouteWithChildren,
   AppOauthConsentRoute: AppOauthConsentRoute,
+  AppPlatformPlatformRoute: AppPlatformPlatformRoute,
   AppTagTagRoute: AppTagTagRoute,
   AppTypeTypeRoute: AppTypeTypeRoute,
 }

--- a/packages/web/src/routes/_app/platform.$platform.tsx
+++ b/packages/web/src/routes/_app/platform.$platform.tsx
@@ -1,0 +1,72 @@
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query'
+import { createFileRoute, notFound, useSearch } from '@tanstack/react-router'
+import { Feed } from '@/components/Feed'
+import { PlatformIcon } from '@/components/PlatformIcon'
+import { createTitle } from '@/constants'
+import { isPlatformId, PLATFORMS } from '@/platforms/catalog'
+import { apiParameters } from '@/utils/fetching/apiParameters'
+import { getPlatformItemsInfiniteOptions } from '@/utils/fetching/platforms'
+
+export const Route = createFileRoute('/_app/platform/$platform')({
+  beforeLoad: ({ params }) => {
+    if (!isPlatformId(params.platform)) {
+      throw notFound()
+    }
+  },
+  component: Page,
+  head: ({ params }) => ({
+    meta: [
+      {
+        title: createTitle(
+          isPlatformId(params.platform)
+            ? PLATFORMS[params.platform].title
+            : 'Platform',
+        ),
+      },
+    ],
+  }),
+  loaderDeps: ({ search }) => ({ search }),
+  validateSearch: (search: Record<string, unknown>) => {
+    const { offset: _, ...params } = apiParameters(search)
+    return params
+  },
+})
+
+function Page() {
+  const { platform } = Route.useParams()
+  const search = useSearch({ from: '/_app/platform/$platform' })
+  const definition = isPlatformId(platform) ? PLATFORMS[platform] : null
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useSuspenseInfiniteQuery(
+      getPlatformItemsInfiniteOptions({
+        params: search,
+        platform: isPlatformId(platform) ? platform : 'bluesky',
+      }),
+    )
+
+  const items = data.pages.flatMap((page) => page.data ?? [])
+  const count = data.pages[0]?.count ?? 0
+
+  return (
+    <Feed
+      items={items}
+      count={count}
+      limit={search.limit}
+      allowGroupByDate={true}
+      title={definition?.title ?? platform}
+      icon={
+        <PlatformIcon
+          platform={platform}
+          aria-label={definition?.title ?? platform}
+          size={24}
+        />
+      }
+      feedType="platformItems"
+      showFeedOptions={false}
+      from="/platform/$platform"
+      hasNextPage={hasNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      fetchNextPage={fetchNextPage}
+    />
+  )
+}

--- a/packages/web/src/routes/_app/settings/-platform-connections.tsx
+++ b/packages/web/src/routes/_app/settings/-platform-connections.tsx
@@ -1,0 +1,236 @@
+import { ArrowsClockwiseIcon } from '@phosphor-icons/react'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Button } from '@/components/Button'
+import { FormGroup } from '@/components/FormGroup'
+import { Input } from '@/components/Input'
+import { Link } from '@/components/Link'
+import { PlatformIcon } from '@/components/PlatformIcon'
+import { Text } from '@/components/Text'
+import {
+  PLATFORM_IDS,
+  PLATFORMS,
+  type PlatformDefinition,
+  type PlatformId,
+} from '@/platforms/catalog'
+import type { PlatformConnection } from '@/types/db'
+import {
+  getPlatformConnectionsOptions,
+  useDeletePlatformMutation,
+  useSyncPlatformMutation,
+  useTogglePlatformMutation,
+  useUpsertPlatformMutation,
+} from '@/utils/fetching/platforms'
+
+export const PlatformConnections = () => {
+  const { data: connections, isLoading } = useQuery(
+    getPlatformConnectionsOptions(),
+  )
+
+  if (isLoading) {
+    return <Text>Loading…</Text>
+  }
+
+  return (
+    <div className="flex flex-col gap-l">
+      <Text>
+        Connect a platform to automatically pull the things you save there —
+        Bluesky bookmarks, GitHub stars, liked YouTube videos — into their own
+        feed in Otter. Synced items can be turned into bookmarks with one click.
+      </Text>
+      {PLATFORM_IDS.map((platform) => (
+        <PlatformConnectionForm
+          connection={connections?.find((item) => item.platform === platform)}
+          definition={PLATFORMS[platform]}
+          key={platform}
+          platform={platform}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface PlatformConnectionFormProps {
+  connection?: PlatformConnection
+  definition: PlatformDefinition
+  platform: PlatformId
+}
+
+const PlatformConnectionForm = ({
+  connection,
+  definition,
+  platform,
+}: PlatformConnectionFormProps) => {
+  const upsertMutation = useUpsertPlatformMutation()
+  const toggleMutation = useTogglePlatformMutation()
+  const deleteMutation = useDeletePlatformMutation()
+  const syncMutation = useSyncPlatformMutation()
+  const [editingFields, setEditingFields] = useState<string[]>([])
+
+  const isConfigured = Boolean(connection)
+  const isEnabled = Boolean(connection?.enabled)
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<Record<string, string>>({
+    defaultValues: Object.fromEntries(
+      definition.credentialFields.map((field) => [field.key, '']),
+    ),
+  })
+
+  const handleSave = (values: Record<string, string>) => {
+    upsertMutation.mutate(
+      { credentials: values, enabled: true, platform },
+      {
+        onSuccess: () => {
+          reset()
+          setEditingFields([])
+        },
+      },
+    )
+  }
+
+  const handleRemove = () => {
+    if (
+      window.confirm(
+        `Remove the ${definition.name} connection and its synced items? Bookmarks you created from them are kept.`,
+      )
+    ) {
+      deleteMutation.mutate({ platform })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-s">
+      <h4 className="flex items-center gap-2xs">
+        <PlatformIcon platform={platform} size={20} />
+        {definition.name}
+        <span className="text-step--2">
+          {isConfigured ? (isEnabled ? '· connected' : '· paused') : ''}
+        </span>
+      </h4>
+      <Text>
+        {definition.description}{' '}
+        {definition.helpUrl ? (
+          <Link href={definition.helpUrl} variant="accent">
+            Learn more
+          </Link>
+        ) : null}
+      </Text>
+
+      {connection?.last_error ? (
+        <div className="rounded bg-destructive/10 p-s text-step--1 text-destructive">
+          {connection.last_error}
+        </div>
+      ) : null}
+
+      <form
+        onSubmit={handleSubmit(handleSave)}
+        noValidate
+        className="flex flex-col gap-s"
+      >
+        {definition.credentialFields.map((field) => {
+          const isSet = connection?.configured_fields.includes(field.key)
+          const isEditing = editingFields.includes(field.key)
+
+          if (isSet && !isEditing) {
+            return (
+              <FormGroup
+                key={field.key}
+                label={field.label}
+                name={`${platform}-${field.key}`}
+                note="Saved. Enter a new value to change it."
+              >
+                <div className="flex items-center gap-s">
+                  <Input
+                    id={`${platform}-${field.key}`}
+                    type={field.type}
+                    value={field.type === 'password' ? '••••••••••••' : 'Saved'}
+                    disabled
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="s"
+                    onClick={() =>
+                      setEditingFields((prev) => [...prev, field.key])
+                    }
+                  >
+                    Change
+                  </Button>
+                </div>
+              </FormGroup>
+            )
+          }
+
+          return (
+            <FormGroup
+              key={field.key}
+              label={field.label}
+              name={`${platform}-${field.key}`}
+              error={errors[field.key]?.message}
+              note={field.note}
+            >
+              <Input
+                id={`${platform}-${field.key}`}
+                type={field.type}
+                placeholder={field.placeholder}
+                autoComplete="off"
+                {...register(field.key, {
+                  required: isSet ? false : `${field.label} is required`,
+                })}
+              />
+            </FormGroup>
+          )
+        })}
+
+        <div className="flex flex-wrap items-center gap-s">
+          <Button type="submit" disabled={upsertMutation.isPending}>
+            {isConfigured ? 'Save' : 'Connect'}
+          </Button>
+          {isConfigured ? (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => syncMutation.mutate({ platform })}
+                disabled={syncMutation.isPending || !isEnabled}
+              >
+                <ArrowsClockwiseIcon size={16} weight="duotone" />
+                {syncMutation.isPending ? 'Syncing…' : 'Sync now'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  toggleMutation.mutate({ enabled: !isEnabled, platform })
+                }
+                disabled={toggleMutation.isPending}
+              >
+                {isEnabled ? 'Pause' : 'Resume'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleRemove}
+                disabled={deleteMutation.isPending}
+              >
+                Remove
+              </Button>
+            </>
+          ) : null}
+        </div>
+      </form>
+
+      {connection?.last_synced_at ? (
+        <Text className="text-step--2">
+          Last synced {new Date(connection.last_synced_at).toLocaleString()}
+        </Text>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/web/src/routes/_app/settings/integrations.tsx
+++ b/packages/web/src/routes/_app/settings/integrations.tsx
@@ -6,6 +6,7 @@ import { Link } from '@/components/Link'
 import { CONTENT } from '@/constants'
 import { getUserProfileOptions } from '@/utils/fetching/user'
 import { BlueskySettings } from './-bluesky-settings'
+import { PlatformConnections } from './-platform-connections'
 
 export const Route = createFileRoute('/_app/settings/integrations')({
   component: RouteComponent,
@@ -32,7 +33,9 @@ function RouteComponent() {
 
   return (
     <article className="flow">
-      <h3>Bluesky</h3>
+      <h3>Platform feeds</h3>
+      <PlatformConnections />
+      <h3>Bluesky cross-posting</h3>
       {userId ? <BlueskySettings userId={userId} /> : null}
       <h3>API key</h3>
       <CodeBlock>{apiKey}</CodeBlock>

--- a/packages/web/src/types/db.ts
+++ b/packages/web/src/types/db.ts
@@ -136,6 +136,37 @@ export interface UserIntegration {
   user_id: string
 }
 
+export interface PlatformItem {
+  bookmark_id: string | null
+  created_at: string
+  description: string | null
+  external_id: string
+  id: string
+  image: string | null
+  ingested_at: string
+  metadata: Json | null
+  platform: string
+  title: string | null
+  url: string | null
+  user_id: string
+}
+
+export interface PlatformItemAuthor {
+  avatar: string | null
+  displayName: string | null
+  handle: string
+}
+
+export interface PlatformConnection {
+  configured_fields: string[]
+  created_at: string
+  enabled: boolean
+  last_error: string | null
+  last_synced_at: string | null
+  platform: string
+  updated_at: string | null
+}
+
 export interface Collection {
   bookmark_count: number | null
   collection: string | null

--- a/packages/web/src/utils/fetching/meta.ts
+++ b/packages/web/src/utils/fetching/meta.ts
@@ -13,7 +13,13 @@ export interface DbMetaResponse {
   likedToots: number
   tweets: number
   likedTweets: number
+  platforms?: MetaPlatform[]
   collections?: CollectionType[]
+}
+
+export interface MetaPlatform {
+  count: number
+  platform: string
 }
 
 export interface MetaTag {

--- a/packages/web/src/utils/fetching/platforms.ts
+++ b/packages/web/src/utils/fetching/platforms.ts
@@ -1,0 +1,270 @@
+import {
+  infiniteQueryOptions,
+  queryOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { DEFAULT_API_RESPONSE_LIMIT } from '@/constants'
+import { PLATFORMS, type PlatformId } from '@/platforms/catalog'
+import type { Bookmark, PlatformConnection, PlatformItem } from '@/types/db'
+import { type ApiParametersQuery, apiParameters } from './apiParameters'
+
+type ApiListResponse<T> = {
+  data: T
+  count: number | null
+  error: null
+}
+
+const queryString = (params: Record<string, unknown>) => {
+  const searchParams = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.set(key, String(value))
+    }
+  }
+
+  const value = searchParams.toString()
+  return value ? `?${value}` : ''
+}
+
+const parseJsonResponse = async <T>(response: Response): Promise<T> => {
+  const body = (await response.json()) as {
+    error?: string
+    reason?: string
+  }
+
+  if (!response.ok) {
+    throw new Error(body.error || body.reason || 'Request failed')
+  }
+
+  return body as T
+}
+
+// Connections
+
+export const getPlatformConnectionsOptions = () => {
+  return queryOptions({
+    queryFn: async () => {
+      const response = await fetch('/api/platforms', {
+        credentials: 'include',
+      })
+      const body = await parseJsonResponse<{ data: PlatformConnection[] }>(
+        response,
+      )
+      return body.data
+    },
+    queryKey: ['platformConnections'],
+  })
+}
+
+interface UpsertPlatformParams {
+  platform: PlatformId
+  credentials: Record<string, string>
+  enabled?: boolean
+}
+
+export const useUpsertPlatformMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      platform,
+      credentials,
+      enabled,
+    }: UpsertPlatformParams) => {
+      const response = await fetch(`/api/platforms/${platform}`, {
+        body: JSON.stringify({ credentials, enabled }),
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        method: 'PUT',
+      })
+
+      await parseJsonResponse<{ data: PlatformConnection }>(response)
+    },
+    onError: (error) => {
+      toast.error(`Failed to save connection: ${error.message}`)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['platformConnections'] })
+    },
+    onSuccess: (_, variables) => {
+      toast.success(`${PLATFORMS[variables.platform].name} connection saved`)
+    },
+  })
+}
+
+export const useTogglePlatformMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      platform,
+      enabled,
+    }: {
+      platform: PlatformId
+      enabled: boolean
+    }) => {
+      const response = await fetch(`/api/platforms/${platform}`, {
+        body: JSON.stringify({ enabled }),
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        method: 'PATCH',
+      })
+
+      await parseJsonResponse<{ data: PlatformConnection }>(response)
+    },
+    onError: (error) => {
+      toast.error(`Failed to update connection: ${error.message}`)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['platformConnections'] })
+    },
+  })
+}
+
+export const useDeletePlatformMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ platform }: { platform: PlatformId }) => {
+      const response = await fetch(`/api/platforms/${platform}`, {
+        credentials: 'include',
+        method: 'DELETE',
+      })
+
+      await parseJsonResponse<{ data: null }>(response)
+    },
+    onError: (error) => {
+      toast.error(`Failed to remove connection: ${error.message}`)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['platformConnections'] })
+      await queryClient.invalidateQueries({ queryKey: ['platformItems'] })
+      await queryClient.invalidateQueries({ queryKey: ['meta'] })
+    },
+    onSuccess: (_, variables) => {
+      toast.success(`${PLATFORMS[variables.platform].name} connection removed`)
+    },
+  })
+}
+
+export const useSyncPlatformMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ platform }: { platform: PlatformId }) => {
+      const response = await fetch(`/api/platforms/${platform}/sync`, {
+        credentials: 'include',
+        method: 'POST',
+      })
+      const body = await parseJsonResponse<{
+        data: { added: number; fetched: number }
+      }>(response)
+      return body.data
+    },
+    onError: (error) => {
+      toast.error(`Sync failed: ${error.message}`)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['platformConnections'] })
+      await queryClient.invalidateQueries({ queryKey: ['platformItems'] })
+      await queryClient.invalidateQueries({ queryKey: ['meta'] })
+    },
+    onSuccess: (result, variables) => {
+      toast.success(
+        `${PLATFORMS[variables.platform].name}: ${result.added} new ${
+          result.added === 1
+            ? PLATFORMS[variables.platform].itemName
+            : `${PLATFORMS[variables.platform].itemName}s`
+        }`,
+      )
+    },
+  })
+}
+
+// Items
+
+interface PlatformItemsFetchingOptions {
+  platform: PlatformId
+  params: Partial<Pick<ApiParametersQuery, 'limit' | 'offset' | 'order'>>
+}
+
+export const getPlatformItems = async ({
+  platform,
+  params,
+}: PlatformItemsFetchingOptions) => {
+  const parsed = apiParameters(params)
+  const response = await fetch(
+    `/api/platform-items${queryString({ ...parsed, platform })}`,
+    {
+      credentials: 'include',
+    },
+  )
+  const body = await parseJsonResponse<{
+    data: PlatformItem[]
+    count: number
+  }>(response)
+
+  return {
+    count: body.count,
+    data: body.data,
+    error: null,
+  } satisfies ApiListResponse<PlatformItem[]>
+}
+
+export const getPlatformItemsInfiniteOptions = ({
+  platform,
+  params,
+}: PlatformItemsFetchingOptions) => {
+  const {
+    limit = DEFAULT_API_RESPONSE_LIMIT,
+    offset: _offset,
+    ...rest
+  } = apiParameters(params)
+  return infiniteQueryOptions({
+    getNextPageParam: (
+      lastPage: Awaited<ReturnType<typeof getPlatformItems>>,
+      _allPages,
+      lastPageParam,
+    ) => {
+      const total = lastPage.count ?? 0
+      const nextOffset = lastPageParam + limit
+      return nextOffset < total ? nextOffset : undefined
+    },
+    initialPageParam: 0,
+    queryFn: ({ pageParam = 0 }) =>
+      getPlatformItems({
+        params: { ...rest, limit, offset: pageParam },
+        platform,
+      }),
+    queryKey: ['platformItems', 'infinite', platform, rest, limit],
+  })
+}
+
+export const useConvertPlatformItemMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id }: { id: string; platform: PlatformId }) => {
+      const response = await fetch(`/api/platform-items/${id}/bookmark`, {
+        credentials: 'include',
+        method: 'POST',
+      })
+      const body = await parseJsonResponse<{ data: Bookmark }>(response)
+      return body.data
+    },
+    onError: (error) => {
+      toast.error(`Failed to add bookmark: ${error.message}`)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['platformItems'] })
+      await queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
+      await queryClient.invalidateQueries({ queryKey: ['meta'] })
+    },
+    onSuccess: () => {
+      toast.success('Bookmark added')
+    },
+  })
+}

--- a/packages/web/worker/hono.ts
+++ b/packages/web/worker/hono.ts
@@ -47,16 +47,25 @@ import {
   renameTag,
 } from './meta'
 import { dbMiddleware } from './middleware/db'
+import {
+  convertPlatformItemToBookmark,
+  deletePlatformConnection,
+  getPlatformConnections,
+  getPlatformItems,
+  syncPlatform,
+  togglePlatformConnection,
+  upsertPlatformConnection,
+} from './platforms/api'
 import { getCurrentProfile, updateCurrentProfile } from './profile'
+import { feedToJson } from './rss/rss-to-json'
+import { handleScrapeContent } from './scraper/scrape-content'
+import { getSearch } from './search/search'
 import {
   createOrRotateShare,
   deleteShare,
   getPublicShare,
   listShares,
 } from './shares'
-import { feedToJson } from './rss/rss-to-json'
-import { handleScrapeContent } from './scraper/scrape-content'
-import { getSearch } from './search/search'
 import {
   getToot,
   getToots,
@@ -262,6 +271,27 @@ api.put('/integrations/bluesky', async (c) => {
 })
 api.patch('/integrations/bluesky', async (c) => {
   return await toggleBlueskyIntegration(c)
+})
+api.get('/platforms', async (c) => {
+  return await getPlatformConnections(c)
+})
+api.put('/platforms/:platform', async (c) => {
+  return await upsertPlatformConnection(c)
+})
+api.patch('/platforms/:platform', async (c) => {
+  return await togglePlatformConnection(c)
+})
+api.delete('/platforms/:platform', async (c) => {
+  return await deletePlatformConnection(c)
+})
+api.post('/platforms/:platform/sync', async (c) => {
+  return await syncPlatform(c)
+})
+api.get('/platform-items', async (c) => {
+  return await getPlatformItems(c)
+})
+api.post('/platform-items/:id/bookmark', async (c) => {
+  return await convertPlatformItemToBookmark(c)
 })
 api.post('/toot', async (c) => {
   return await sendToots(c)

--- a/packages/web/worker/index.ts
+++ b/packages/web/worker/index.ts
@@ -1,8 +1,16 @@
+import type { WorkerEnv } from './env'
 import { app } from './hono'
+import { syncAllPlatformConnections } from './platforms/sync'
 
 // https://hono.dev/docs/getting-started/cloudflare-workers#using-hono-with-other-event-handlers
 export default {
   fetch: app.fetch,
 
-  // scheduled: async (batch, env) => {},
+  scheduled: (
+    _controller: ScheduledController,
+    env: WorkerEnv,
+    ctx: ExecutionContext,
+  ) => {
+    ctx.waitUntil(syncAllPlatformConnections(env))
+  },
 }

--- a/packages/web/worker/meta.ts
+++ b/packages/web/worker/meta.ts
@@ -5,7 +5,7 @@ import { apiParameters } from '@/utils/fetching/apiParameters'
 import { errorResponse } from '@/utils/fetching/errorResponse'
 import type { MetaTag, MetaType } from '@/utils/fetching/meta'
 import { getErrorMessage } from '@/utils/get-error-message'
-import { bookmarks, toots, tweets } from '../db/schema'
+import { bookmarks, platformItems, toots, tweets } from '../db/schema'
 import { bookmarkToRow } from './bookmarks/mapper'
 import { summariseCollections, tagBelongsToCollection } from './collections'
 import { requireRequestContext } from './context'
@@ -118,6 +118,7 @@ export const getMeta = async (context: HonoContext) => {
       likedToots,
       tweetsCount,
       likedTweets,
+      platformCounts,
     ] = await Promise.all([
       countBookmarks(auth),
       countBookmarks(auth, gte(bookmarks.clickCount, 1)),
@@ -163,6 +164,17 @@ export const getMeta = async (context: HonoContext) => {
           .where(eq(tweets.likedTweet, true))
         return value ?? 0
       })(),
+      (async () => {
+        const rows = await auth.requestContext.db
+          .select({ platform: platformItems.platform, value: count() })
+          .from(platformItems)
+          .where(eq(platformItems.userId, auth.userId))
+          .groupBy(platformItems.platform)
+        return rows.map((row) => ({
+          count: row.value ?? 0,
+          platform: row.platform,
+        }))
+      })(),
     ])
 
     return new Response(
@@ -171,6 +183,7 @@ export const getMeta = async (context: HonoContext) => {
         collections: summariseCollections(rows),
         likedToots,
         likedTweets,
+        platforms: platformCounts,
         public: publicItems,
         stars,
         tags: tagCounts(rows),

--- a/packages/web/worker/platforms/api.ts
+++ b/packages/web/worker/platforms/api.ts
@@ -1,0 +1,455 @@
+import { and, asc, count, desc, eq } from 'drizzle-orm'
+import type { Context } from 'hono'
+import { API_HEADERS, DEFAULT_API_RESPONSE_LIMIT } from '@/constants'
+import { isPlatformId, type PlatformId } from '@/platforms/catalog'
+import { apiParameters } from '@/utils/fetching/apiParameters'
+import { apiResponseGenerator } from '@/utils/fetching/apiResponse'
+import { errorResponse } from '@/utils/fetching/errorResponse'
+import { getErrorMessage } from '@/utils/get-error-message'
+import { searchParamsToObject } from '@/utils/searchParamsToObject'
+import { bookmarks, platformConnections, platformItems } from '../../db/schema'
+import { bookmarkToRow } from '../bookmarks/mapper'
+import { requireRequestContext } from '../context'
+import type { WorkerEnv } from '../env'
+import { syncPlatformConnection } from './sync'
+import type { PlatformCredentials } from './types'
+
+type HonoContext = Context<{ Bindings: WorkerEnv }>
+type ConnectionRow = typeof platformConnections.$inferSelect
+type ItemRow = typeof platformItems.$inferSelect
+
+// Credentials never leave the server — clients only learn which keys are set
+const connectionToRow = (row: ConnectionRow) => ({
+  configured_fields: Object.entries(
+    (row.credentials ?? {}) as PlatformCredentials,
+  )
+    .filter(([, value]) => Boolean(value))
+    .map(([key]) => key),
+  created_at: row.createdAt.toISOString(),
+  enabled: row.enabled,
+  last_error: row.lastError,
+  last_synced_at: row.lastSyncedAt?.toISOString() ?? null,
+  platform: row.platform,
+  updated_at: row.updatedAt?.toISOString() ?? null,
+})
+
+const itemToRow = (item: ItemRow) => ({
+  bookmark_id: item.bookmarkId,
+  created_at: item.createdAt.toISOString(),
+  description: item.description,
+  external_id: item.externalId,
+  id: item.id,
+  image: item.image,
+  ingested_at: item.ingestedAt.toISOString(),
+  metadata: item.metadata,
+  platform: item.platform,
+  title: item.title,
+  url: item.url,
+  user_id: item.userId,
+})
+
+const getAuthed = async (context: HonoContext) => {
+  const requestContext = await requireRequestContext(context)
+
+  if (requestContext instanceof Response) {
+    return requestContext
+  }
+
+  const userId = requestContext.user?.id
+
+  if (!userId) {
+    return errorResponse({ reason: 'Not authorised', status: 401 })
+  }
+
+  return { requestContext, userId }
+}
+
+const getPlatformParam = (context: HonoContext): PlatformId | Response => {
+  const platform = context.req.param('platform')
+
+  if (!platform || !isPlatformId(platform)) {
+    return errorResponse({
+      error: `Unknown platform: ${platform}`,
+      reason: 'Unknown platform',
+      status: 404,
+    })
+  }
+
+  return platform
+}
+
+const findConnection = async (
+  auth: Exclude<Awaited<ReturnType<typeof getAuthed>>, Response>,
+  platform: PlatformId,
+) =>
+  await auth.requestContext.db.query.platformConnections.findFirst({
+    where: and(
+      eq(platformConnections.userId, auth.userId),
+      eq(platformConnections.platform, platform),
+    ),
+  })
+
+export const getPlatformConnections = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context)
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const connections = await auth.requestContext.db
+      .select()
+      .from(platformConnections)
+      .where(eq(platformConnections.userId, auth.userId))
+      .orderBy(asc(platformConnections.platform))
+
+    return new Response(
+      JSON.stringify({ data: connections.map(connectionToRow), error: null }),
+      { headers: API_HEADERS, status: 200 },
+    )
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem getting platform connections',
+      status: 400,
+    })
+  }
+}
+
+export const upsertPlatformConnection = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context)
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const platform = getPlatformParam(context)
+
+    if (platform instanceof Response) {
+      return platform
+    }
+
+    const body = (await context.req.json()) as {
+      credentials?: PlatformCredentials
+      enabled?: boolean
+    }
+    const existing = await findConnection(auth, platform)
+    const existingCredentials = (existing?.credentials ??
+      {}) as PlatformCredentials
+    // Blank fields keep their stored value, so users can update a single
+    // credential without re-entering secrets
+    const credentials: PlatformCredentials = { ...existingCredentials }
+
+    for (const [key, value] of Object.entries(body.credentials ?? {})) {
+      if (value?.trim()) {
+        credentials[key] = value.trim()
+      }
+    }
+
+    const [connection] = await auth.requestContext.db
+      .insert(platformConnections)
+      .values({
+        credentials,
+        enabled: body.enabled ?? true,
+        lastError: null,
+        platform,
+        updatedAt: new Date(),
+        userId: auth.userId,
+      })
+      .onConflictDoUpdate({
+        set: {
+          credentials,
+          enabled: body.enabled ?? existing?.enabled ?? true,
+          lastError: null,
+          updatedAt: new Date(),
+        },
+        target: [platformConnections.userId, platformConnections.platform],
+      })
+      .returning()
+
+    return new Response(
+      JSON.stringify({ data: connectionToRow(connection), error: null }),
+      { headers: API_HEADERS, status: 200 },
+    )
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem saving platform connection',
+      status: 400,
+    })
+  }
+}
+
+export const togglePlatformConnection = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context)
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const platform = getPlatformParam(context)
+
+    if (platform instanceof Response) {
+      return platform
+    }
+
+    const body = (await context.req.json()) as { enabled: boolean }
+    const [connection] = await auth.requestContext.db
+      .update(platformConnections)
+      .set({ enabled: body.enabled, lastError: null, updatedAt: new Date() })
+      .where(
+        and(
+          eq(platformConnections.userId, auth.userId),
+          eq(platformConnections.platform, platform),
+        ),
+      )
+      .returning()
+
+    if (!connection) {
+      return errorResponse({
+        error: 'Connection not found',
+        reason: 'Connection not found',
+        status: 404,
+      })
+    }
+
+    return new Response(
+      JSON.stringify({ data: connectionToRow(connection), error: null }),
+      { headers: API_HEADERS, status: 200 },
+    )
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem updating platform connection',
+      status: 400,
+    })
+  }
+}
+
+export const deletePlatformConnection = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context)
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const platform = getPlatformParam(context)
+
+    if (platform instanceof Response) {
+      return platform
+    }
+
+    // Synced items go too; bookmarks created from them are kept
+    await auth.requestContext.db
+      .delete(platformItems)
+      .where(
+        and(
+          eq(platformItems.userId, auth.userId),
+          eq(platformItems.platform, platform),
+        ),
+      )
+    await auth.requestContext.db
+      .delete(platformConnections)
+      .where(
+        and(
+          eq(platformConnections.userId, auth.userId),
+          eq(platformConnections.platform, platform),
+        ),
+      )
+
+    return new Response(JSON.stringify({ data: null, error: null }), {
+      headers: API_HEADERS,
+      status: 200,
+    })
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem removing platform connection',
+      status: 400,
+    })
+  }
+}
+
+export const syncPlatform = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context)
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const platform = getPlatformParam(context)
+
+    if (platform instanceof Response) {
+      return platform
+    }
+
+    const connection = await findConnection(auth, platform)
+
+    if (!connection) {
+      return errorResponse({
+        error: 'Connection not found',
+        reason: 'Connection not found',
+        status: 404,
+      })
+    }
+
+    const result = await syncPlatformConnection(
+      auth.requestContext.db,
+      connection,
+    )
+
+    return new Response(JSON.stringify({ data: result, error: null }), {
+      headers: API_HEADERS,
+      status: 200,
+    })
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem syncing platform',
+      status: 400,
+    })
+  }
+}
+
+export const getPlatformItems = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context)
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const platform = context.req.query('platform')
+
+    if (!platform || !isPlatformId(platform)) {
+      return errorResponse({
+        error: `Unknown platform: ${platform}`,
+        reason: 'Unknown platform',
+        status: 404,
+      })
+    }
+
+    const {
+      limit = DEFAULT_API_RESPONSE_LIMIT,
+      offset = 0,
+      order,
+    } = apiParameters(searchParamsToObject(context.req.url))
+    const where = and(
+      eq(platformItems.userId, auth.userId),
+      eq(platformItems.platform, platform),
+    )
+    const [{ value: total }] = await auth.requestContext.db
+      .select({ value: count() })
+      .from(platformItems)
+      .where(where)
+    const data = await auth.requestContext.db
+      .select()
+      .from(platformItems)
+      .where(where)
+      .orderBy(
+        order === 'asc'
+          ? asc(platformItems.createdAt)
+          : desc(platformItems.createdAt),
+      )
+      .limit(limit)
+      .offset(offset)
+
+    return new Response(
+      JSON.stringify(
+        apiResponseGenerator({
+          count: total ?? 0,
+          data: data.map(itemToRow),
+          limit,
+          offset,
+          path: context.req.url,
+        }),
+      ),
+      { headers: API_HEADERS, status: 200 },
+    )
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem getting platform items',
+      status: 400,
+    })
+  }
+}
+
+export const convertPlatformItemToBookmark = async (context: HonoContext) => {
+  try {
+    const auth = await getAuthed(context)
+
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const id = context.req.param('id')
+
+    if (!id) {
+      return errorResponse({ reason: 'Missing item id', status: 400 })
+    }
+
+    const item = await auth.requestContext.db.query.platformItems.findFirst({
+      where: and(
+        eq(platformItems.id, id),
+        eq(platformItems.userId, auth.userId),
+      ),
+    })
+
+    if (!item) {
+      return errorResponse({
+        error: 'Item not found',
+        reason: 'Item not found or access denied',
+        status: 404,
+      })
+    }
+
+    if (item.bookmarkId) {
+      const [existing] = await auth.requestContext.db
+        .select()
+        .from(bookmarks)
+        .where(eq(bookmarks.id, item.bookmarkId))
+        .limit(1)
+
+      if (existing) {
+        return new Response(
+          JSON.stringify({ data: bookmarkToRow(existing), error: null }),
+          { headers: API_HEADERS, status: 200 },
+        )
+      }
+    }
+
+    const [bookmark] = await auth.requestContext.db
+      .insert(bookmarks)
+      .values({
+        description: item.description,
+        image: item.image,
+        tags: [item.platform],
+        title: item.title,
+        type: item.platform === 'youtube' ? 'video' : 'link',
+        url: item.url,
+        user: auth.userId,
+      })
+      .returning()
+
+    await auth.requestContext.db
+      .update(platformItems)
+      .set({ bookmarkId: bookmark.id })
+      .where(eq(platformItems.id, item.id))
+
+    return new Response(
+      JSON.stringify({ data: bookmarkToRow(bookmark), error: null }),
+      { headers: API_HEADERS, status: 201 },
+    )
+  } catch (error) {
+    return errorResponse({
+      error: getErrorMessage(error),
+      reason: 'Problem creating bookmark from item',
+      status: 400,
+    })
+  }
+}

--- a/packages/web/worker/platforms/bluesky.test.ts
+++ b/packages/web/worker/platforms/bluesky.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type BlueskyBookmarkView,
+  blueskyPostUrl,
+  mapBlueskyBookmark,
+} from './bluesky'
+
+describe('blueskyPostUrl', () => {
+  it('converts an at:// uri to a bsky.app url using the handle', () => {
+    expect(
+      blueskyPostUrl(
+        'at://did:plc:abc123/app.bsky.feed.post/3kxyz',
+        'zander.bsky.social',
+      ),
+    ).toBe('https://bsky.app/profile/zander.bsky.social/post/3kxyz')
+  })
+
+  it('falls back to the did when no handle is available', () => {
+    expect(blueskyPostUrl('at://did:plc:abc123/app.bsky.feed.post/3kxyz')).toBe(
+      'https://bsky.app/profile/did:plc:abc123/post/3kxyz',
+    )
+  })
+
+  it('returns null for non-post uris', () => {
+    expect(blueskyPostUrl('at://did:plc:abc123/app.bsky.feed.like/3kxyz')).toBe(
+      null,
+    )
+  })
+})
+
+describe('mapBlueskyBookmark', () => {
+  const post = {
+    author: {
+      avatar: 'https://cdn.bsky.app/avatar.jpg',
+      did: 'did:plc:abc123',
+      displayName: 'Zander',
+      handle: 'zander.bsky.social',
+    },
+    record: {
+      createdAt: '2026-05-30T09:00:00.000Z',
+      text: 'First line of the post\nSecond line',
+    },
+    uri: 'at://did:plc:abc123/app.bsky.feed.post/3kxyz',
+  }
+  const bookmark: BlueskyBookmarkView = {
+    createdAt: '2026-06-01T10:00:00.000Z',
+    item: post,
+    subject: { uri: 'at://did:plc:abc123/app.bsky.feed.post/3kxyz' },
+  }
+
+  it('maps a bookmarked post to a platform item', () => {
+    const item = mapBlueskyBookmark(bookmark)
+
+    expect(item.externalId).toBe('at://did:plc:abc123/app.bsky.feed.post/3kxyz')
+    expect(item.title).toBe('First line of the post')
+    expect(item.description).toBe('First line of the post\nSecond line')
+    expect(item.url).toBe(
+      'https://bsky.app/profile/zander.bsky.social/post/3kxyz',
+    )
+    expect(item.createdAt).toEqual(new Date('2026-06-01T10:00:00.000Z'))
+    expect(item.metadata).toEqual({
+      author: {
+        avatar: 'https://cdn.bsky.app/avatar.jpg',
+        displayName: 'Zander',
+        handle: 'zander.bsky.social',
+      },
+    })
+  })
+
+  it('truncates long first lines for the title', () => {
+    const longText = 'a'.repeat(150)
+    const item = mapBlueskyBookmark({
+      ...bookmark,
+      item: {
+        ...post,
+        record: { text: longText },
+      },
+    })
+
+    expect(item.title).toBe(`${'a'.repeat(100)}…`)
+    expect(item.description).toBe(longText)
+  })
+
+  it('falls back to an author-based title when the post has no text', () => {
+    const item = mapBlueskyBookmark({
+      ...bookmark,
+      item: { ...post, record: { text: '' } },
+    })
+
+    expect(item.title).toBe('Post by @zander.bsky.social')
+    expect(item.description).toBe(null)
+  })
+})

--- a/packages/web/worker/platforms/bluesky.ts
+++ b/packages/web/worker/platforms/bluesky.ts
@@ -1,0 +1,144 @@
+import {
+  DEFAULT_SYNC_LIMIT,
+  type PlatformFetcher,
+  type PlatformItemInput,
+  requireCredential,
+} from './types'
+
+const BLUESKY_SERVICE = 'https://bsky.social'
+const PAGE_SIZE = 100
+
+interface BlueskyAuthor {
+  avatar?: string
+  did: string
+  displayName?: string
+  handle: string
+}
+
+interface BlueskyPostView {
+  author: BlueskyAuthor
+  embed?: {
+    external?: { thumb?: string; title?: string; uri?: string }
+    images?: { thumb?: string }[]
+  }
+  record?: { createdAt?: string; text?: string }
+  uri: string
+}
+
+export interface BlueskyBookmarkView {
+  createdAt?: string
+  item?: BlueskyPostView & { $type?: string }
+  subject: { cid?: string; uri: string }
+}
+
+/** at://did:plc:xxx/app.bsky.feed.post/rkey → https://bsky.app/profile/{handle}/post/{rkey} */
+export const blueskyPostUrl = (
+  uri: string,
+  authorHandle?: string,
+): string | null => {
+  const match = uri.match(/^at:\/\/([^/]+)\/app\.bsky\.feed\.post\/([^/]+)$/)
+
+  if (!match) {
+    return null
+  }
+
+  const [, did, rkey] = match
+  return `https://bsky.app/profile/${authorHandle || did}/post/${rkey}`
+}
+
+export const mapBlueskyBookmark = (
+  bookmark: BlueskyBookmarkView,
+): PlatformItemInput => {
+  const post = bookmark.item
+  const author = post?.author
+  const text = post?.record?.text?.trim() ?? ''
+  const firstLine = text.split('\n')[0]?.trim() ?? ''
+  const title = firstLine
+    ? firstLine.length > 100
+      ? `${firstLine.slice(0, 100)}…`
+      : firstLine
+    : author
+      ? `Post by @${author.handle}`
+      : 'Bluesky post'
+  const image =
+    post?.embed?.images?.[0]?.thumb ?? post?.embed?.external?.thumb ?? null
+
+  return {
+    createdAt: bookmark.createdAt ? new Date(bookmark.createdAt) : undefined,
+    description: text || null,
+    externalId: bookmark.subject.uri,
+    image,
+    metadata: author
+      ? {
+          author: {
+            avatar: author.avatar ?? null,
+            displayName: author.displayName ?? null,
+            handle: author.handle,
+          },
+        }
+      : null,
+    title,
+    url: blueskyPostUrl(bookmark.subject.uri, author?.handle),
+  }
+}
+
+const createSession = async (identifier: string, password: string) => {
+  const response = await fetch(
+    `${BLUESKY_SERVICE}/xrpc/com.atproto.server.createSession`,
+    {
+      body: JSON.stringify({ identifier, password }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    },
+  )
+
+  if (!response.ok) {
+    throw new Error(`Bluesky sign-in failed (${response.status})`)
+  }
+
+  return (await response.json()) as { accessJwt: string; did: string }
+}
+
+export const fetchBlueskyBookmarks: PlatformFetcher = async ({
+  credentials,
+  limit = DEFAULT_SYNC_LIMIT,
+}) => {
+  const handle = requireCredential(credentials, 'handle', 'Bluesky')
+  const appPassword = requireCredential(credentials, 'appPassword', 'Bluesky')
+  const session = await createSession(handle, appPassword)
+  const items: PlatformItemInput[] = []
+  let cursor: string | undefined
+
+  while (items.length < limit) {
+    const params = new URLSearchParams({ limit: String(PAGE_SIZE) })
+
+    if (cursor) {
+      params.set('cursor', cursor)
+    }
+
+    const response = await fetch(
+      `${BLUESKY_SERVICE}/xrpc/app.bsky.bookmark.getBookmarks?${params}`,
+      { headers: { Authorization: `Bearer ${session.accessJwt}` } },
+    )
+
+    if (!response.ok) {
+      throw new Error(`Bluesky bookmarks request failed (${response.status})`)
+    }
+
+    const body = (await response.json()) as {
+      bookmarks?: BlueskyBookmarkView[]
+      cursor?: string
+    }
+    const bookmarks = body.bookmarks ?? []
+
+    items.push(...bookmarks.map(mapBlueskyBookmark))
+
+    if (!body.cursor || bookmarks.length === 0) {
+      break
+    }
+
+    cursor = body.cursor
+  }
+
+  return items.slice(0, limit)
+}

--- a/packages/web/worker/platforms/github.test.ts
+++ b/packages/web/worker/platforms/github.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { type GithubStarView, mapGithubStar } from './github'
+
+describe('mapGithubStar', () => {
+  const star: GithubStarView = {
+    repo: {
+      description: 'A self-hosted bookmark manager',
+      full_name: 'mrmartineau/Otter',
+      html_url: 'https://github.com/mrmartineau/Otter',
+      id: 12345,
+      language: 'TypeScript',
+      owner: { avatar_url: 'https://avatars.githubusercontent.com/u/1' },
+      stargazers_count: 420,
+    },
+    starred_at: '2026-06-01T10:00:00Z',
+  }
+
+  it('maps a starred repo to a platform item', () => {
+    const item = mapGithubStar(star)
+
+    expect(item.externalId).toBe('12345')
+    expect(item.title).toBe('mrmartineau/Otter')
+    expect(item.description).toBe('A self-hosted bookmark manager')
+    expect(item.url).toBe('https://github.com/mrmartineau/Otter')
+    expect(item.image).toBe('https://avatars.githubusercontent.com/u/1')
+    expect(item.createdAt).toEqual(new Date('2026-06-01T10:00:00Z'))
+    expect(item.metadata).toEqual({ language: 'TypeScript', stars: 420 })
+  })
+
+  it('handles missing optional fields', () => {
+    const item = mapGithubStar({
+      repo: {
+        full_name: 'someone/repo',
+        html_url: 'https://github.com/someone/repo',
+        id: 99,
+      },
+    })
+
+    expect(item.createdAt).toBeUndefined()
+    expect(item.description).toBe(null)
+    expect(item.image).toBe(null)
+    expect(item.metadata).toEqual({ language: null, stars: null })
+  })
+})

--- a/packages/web/worker/platforms/github.ts
+++ b/packages/web/worker/platforms/github.ts
@@ -1,0 +1,76 @@
+import {
+  DEFAULT_SYNC_LIMIT,
+  type PlatformFetcher,
+  type PlatformItemInput,
+  requireCredential,
+} from './types'
+
+const PAGE_SIZE = 100
+
+export interface GithubStarView {
+  repo: {
+    description?: string | null
+    full_name: string
+    html_url: string
+    id: number
+    language?: string | null
+    owner?: { avatar_url?: string }
+    stargazers_count?: number
+  }
+  starred_at?: string
+}
+
+export const mapGithubStar = (star: GithubStarView): PlatformItemInput => ({
+  createdAt: star.starred_at ? new Date(star.starred_at) : undefined,
+  description: star.repo.description ?? null,
+  externalId: String(star.repo.id),
+  image: star.repo.owner?.avatar_url ?? null,
+  metadata: {
+    language: star.repo.language ?? null,
+    stars: star.repo.stargazers_count ?? null,
+  },
+  title: star.repo.full_name,
+  url: star.repo.html_url,
+})
+
+export const fetchGithubStars: PlatformFetcher = async ({
+  credentials,
+  limit = DEFAULT_SYNC_LIMIT,
+}) => {
+  const token = requireCredential(credentials, 'token', 'GitHub')
+  const items: PlatformItemInput[] = []
+  let page = 1
+
+  while (items.length < limit) {
+    const response = await fetch(
+      `https://api.github.com/user/starred?per_page=${PAGE_SIZE}&page=${page}`,
+      {
+        headers: {
+          // The star+json media type includes starred_at timestamps
+          Accept: 'application/vnd.github.star+json',
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'otter-bookmark-manager',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    )
+
+    if (!response.ok) {
+      throw new Error(
+        `GitHub starred repos request failed (${response.status})`,
+      )
+    }
+
+    const stars = (await response.json()) as GithubStarView[]
+
+    items.push(...stars.map(mapGithubStar))
+
+    if (stars.length < PAGE_SIZE) {
+      break
+    }
+
+    page += 1
+  }
+
+  return items.slice(0, limit)
+}

--- a/packages/web/worker/platforms/registry.ts
+++ b/packages/web/worker/platforms/registry.ts
@@ -1,0 +1,16 @@
+import type { PlatformId } from '@/platforms/catalog'
+import { fetchBlueskyBookmarks } from './bluesky'
+import { fetchGithubStars } from './github'
+import type { PlatformFetcher } from './types'
+import { fetchYoutubeLikes } from './youtube'
+
+/**
+ * Server-side counterpart of `src/platforms/catalog.ts`: one fetcher per
+ * platform id. The `satisfies` check guarantees every catalog entry has a
+ * fetcher (and vice versa) at compile time.
+ */
+export const platformFetchers = {
+  bluesky: fetchBlueskyBookmarks,
+  github: fetchGithubStars,
+  youtube: fetchYoutubeLikes,
+} satisfies Record<PlatformId, PlatformFetcher>

--- a/packages/web/worker/platforms/sync.ts
+++ b/packages/web/worker/platforms/sync.ts
@@ -1,0 +1,104 @@
+import { and, eq } from 'drizzle-orm'
+import { isPlatformId } from '@/platforms/catalog'
+import { getErrorMessage } from '@/utils/get-error-message'
+import { createDbClient, type Db, type DbEnv } from '../../db/client'
+import { platformConnections, platformItems } from '../../db/schema'
+import { platformFetchers } from './registry'
+import type { PlatformCredentials } from './types'
+
+type ConnectionRow = typeof platformConnections.$inferSelect
+
+export interface SyncResult {
+  added: number
+  fetched: number
+}
+
+export const syncPlatformConnection = async (
+  db: Db,
+  connection: ConnectionRow,
+): Promise<SyncResult> => {
+  if (!isPlatformId(connection.platform)) {
+    throw new Error(`Unknown platform: ${connection.platform}`)
+  }
+
+  try {
+    const fetcher = platformFetchers[connection.platform]
+    const items = await fetcher({
+      credentials: (connection.credentials ?? {}) as PlatformCredentials,
+    })
+    let added = 0
+
+    if (items.length) {
+      const inserted = await db
+        .insert(platformItems)
+        .values(
+          items.map((item) => ({
+            createdAt: item.createdAt,
+            description: item.description ?? null,
+            externalId: item.externalId,
+            image: item.image ?? null,
+            metadata: item.metadata ?? null,
+            platform: connection.platform,
+            title: item.title ?? null,
+            url: item.url ?? null,
+            userId: connection.userId,
+          })),
+        )
+        .onConflictDoNothing({
+          target: [
+            platformItems.userId,
+            platformItems.platform,
+            platformItems.externalId,
+          ],
+        })
+        .returning({ id: platformItems.id })
+
+      added = inserted.length
+    }
+
+    await db
+      .update(platformConnections)
+      .set({ lastError: null, lastSyncedAt: new Date(), updatedAt: new Date() })
+      .where(eq(platformConnections.id, connection.id))
+
+    return { added, fetched: items.length }
+  } catch (error) {
+    await db
+      .update(platformConnections)
+      .set({ lastError: getErrorMessage(error), updatedAt: new Date() })
+      .where(eq(platformConnections.id, connection.id))
+
+    throw error
+  }
+}
+
+/**
+ * Entry point for the Worker's scheduled (cron) handler: sync every enabled
+ * connection across all users. Failures are recorded on the connection
+ * (lastError) and don't stop the rest of the batch.
+ */
+export const syncAllPlatformConnections = async (env: DbEnv) => {
+  const { client, db } = createDbClient(env)
+
+  await client.connect()
+
+  try {
+    const connections = await db
+      .select()
+      .from(platformConnections)
+      .where(and(eq(platformConnections.enabled, true)))
+
+    for (const connection of connections) {
+      try {
+        await syncPlatformConnection(db, connection)
+      } catch (error) {
+        console.error(
+          `Platform sync failed (${connection.platform}, user ${connection.userId}):`,
+          getErrorMessage(error),
+        )
+      }
+    }
+  } finally {
+    await client.end()
+  }
+}

--- a/packages/web/worker/platforms/types.ts
+++ b/packages/web/worker/platforms/types.ts
@@ -1,0 +1,37 @@
+export type PlatformCredentials = Record<string, string>
+
+export interface PlatformItemInput {
+  createdAt?: Date
+  description?: string | null
+  externalId: string
+  image?: string | null
+  metadata?: unknown
+  title?: string | null
+  url?: string | null
+}
+
+export interface PlatformFetchArgs {
+  credentials: PlatformCredentials
+  /** Soft cap on how many items a single sync should fetch */
+  limit?: number
+}
+
+export type PlatformFetcher = (
+  args: PlatformFetchArgs,
+) => Promise<PlatformItemInput[]>
+
+export const DEFAULT_SYNC_LIMIT = 200
+
+export const requireCredential = (
+  credentials: PlatformCredentials,
+  key: string,
+  platform: string,
+): string => {
+  const value = credentials[key]?.trim()
+
+  if (!value) {
+    throw new Error(`Missing ${platform} credential: ${key}`)
+  }
+
+  return value
+}

--- a/packages/web/worker/platforms/youtube.test.ts
+++ b/packages/web/worker/platforms/youtube.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { mapYoutubeVideo, type YoutubeVideoView } from './youtube'
+
+describe('mapYoutubeVideo', () => {
+  const video: YoutubeVideoView = {
+    id: 'dQw4w9WgXcQ',
+    snippet: {
+      channelTitle: 'A Channel',
+      description: 'A video description',
+      publishedAt: '2026-06-01T10:00:00Z',
+      thumbnails: {
+        default: { url: 'https://i.ytimg.com/default.jpg' },
+        medium: { url: 'https://i.ytimg.com/medium.jpg' },
+      },
+      title: 'A liked video',
+    },
+  }
+
+  it('maps a liked video to a platform item', () => {
+    const item = mapYoutubeVideo(video)
+
+    expect(item.externalId).toBe('dQw4w9WgXcQ')
+    expect(item.title).toBe('A liked video')
+    expect(item.url).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    expect(item.image).toBe('https://i.ytimg.com/medium.jpg')
+    expect(item.createdAt).toEqual(new Date('2026-06-01T10:00:00Z'))
+    expect(item.metadata).toEqual({ channelTitle: 'A Channel' })
+  })
+
+  it('truncates very long descriptions', () => {
+    const item = mapYoutubeVideo({
+      ...video,
+      snippet: { ...video.snippet, description: 'x'.repeat(600) },
+    })
+
+    expect(item.description).toBe(`${'x'.repeat(500)}…`)
+  })
+
+  it('falls back across thumbnail sizes', () => {
+    const item = mapYoutubeVideo({
+      ...video,
+      snippet: {
+        ...video.snippet,
+        thumbnails: { default: { url: 'https://i.ytimg.com/default.jpg' } },
+      },
+    })
+
+    expect(item.image).toBe('https://i.ytimg.com/default.jpg')
+  })
+})

--- a/packages/web/worker/platforms/youtube.ts
+++ b/packages/web/worker/platforms/youtube.ts
@@ -1,0 +1,124 @@
+import {
+  DEFAULT_SYNC_LIMIT,
+  type PlatformFetcher,
+  type PlatformItemInput,
+  requireCredential,
+} from './types'
+
+const PAGE_SIZE = 50
+
+export interface YoutubeVideoView {
+  id: string
+  snippet?: {
+    channelTitle?: string
+    description?: string
+    publishedAt?: string
+    thumbnails?: Record<string, { url?: string }>
+    title?: string
+  }
+}
+
+export const mapYoutubeVideo = (video: YoutubeVideoView): PlatformItemInput => {
+  const thumbnails = video.snippet?.thumbnails
+  const image =
+    thumbnails?.medium?.url ??
+    thumbnails?.high?.url ??
+    thumbnails?.default?.url ??
+    null
+  const description = video.snippet?.description?.trim() ?? ''
+
+  return {
+    createdAt: video.snippet?.publishedAt
+      ? new Date(video.snippet.publishedAt)
+      : undefined,
+    description: description
+      ? description.length > 500
+        ? `${description.slice(0, 500)}…`
+        : description
+      : null,
+    externalId: video.id,
+    image,
+    metadata: { channelTitle: video.snippet?.channelTitle ?? null },
+    title: video.snippet?.title ?? 'YouTube video',
+    url: `https://www.youtube.com/watch?v=${video.id}`,
+  }
+}
+
+const getAccessToken = async (
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+) => {
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    }),
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    throw new Error(`YouTube token refresh failed (${response.status})`)
+  }
+
+  const body = (await response.json()) as { access_token?: string }
+
+  if (!body.access_token) {
+    throw new Error('YouTube token refresh returned no access token')
+  }
+
+  return body.access_token
+}
+
+export const fetchYoutubeLikes: PlatformFetcher = async ({
+  credentials,
+  limit = DEFAULT_SYNC_LIMIT,
+}) => {
+  const clientId = requireCredential(credentials, 'clientId', 'YouTube')
+  const clientSecret = requireCredential(credentials, 'clientSecret', 'YouTube')
+  const refreshToken = requireCredential(credentials, 'refreshToken', 'YouTube')
+  const accessToken = await getAccessToken(clientId, clientSecret, refreshToken)
+  const items: PlatformItemInput[] = []
+  let pageToken: string | undefined
+
+  while (items.length < limit) {
+    const params = new URLSearchParams({
+      maxResults: String(PAGE_SIZE),
+      myRating: 'like',
+      part: 'snippet',
+    })
+
+    if (pageToken) {
+      params.set('pageToken', pageToken)
+    }
+
+    const response = await fetch(
+      `https://www.googleapis.com/youtube/v3/videos?${params}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    )
+
+    if (!response.ok) {
+      throw new Error(
+        `YouTube liked videos request failed (${response.status})`,
+      )
+    }
+
+    const body = (await response.json()) as {
+      items?: YoutubeVideoView[]
+      nextPageToken?: string
+    }
+    const videos = body.items ?? []
+
+    items.push(...videos.map(mapYoutubeVideo))
+
+    if (!body.nextPageToken || videos.length === 0) {
+      break
+    }
+
+    pageToken = body.nextPageToken
+  }
+
+  return items.slice(0, limit)
+}

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -60,6 +60,10 @@
       "zone_name": "zander.wtf"
     }
   ],
+  /* Periodic platform-feed sync (Bluesky bookmarks, GitHub stars, …) */
+  "triggers": {
+    "crons": ["17 */6 * * *"]
+  },
   /**
    * Environment Variables
    * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables


### PR DESCRIPTION
## What

A generic **platform feeds** system: things you save on other platforms (Bluesky bookmarks, GitHub stars, liked YouTube videos) are synced into their own feed sections in Otter, with connection/credential management inside the app. Unlike the legacy tweets/toots pairs, nothing here is per-platform copy-paste — adding a platform is a config entry plus one fetch function.

## How it fits together

**Shared catalog drives everything** — `src/platforms/catalog.ts` is pure data (name, feed title, description, credential field specs) imported by both the Worker and the SPA:
- the settings form for each platform is *generated* from its `credentialFields`
- the feed page title/icon, sidebar entries, and toasts all come from the same entry
- `worker/platforms/registry.ts` maps each catalog id to a server-side fetcher; a `satisfies Record<PlatformId, PlatformFetcher>` check makes the compiler enforce that every catalog entry has a fetcher

**Adding a platform** = one catalog entry + one fetcher (`PlatformFetcher` returns normalised `{externalId, url, title, description, image, createdAt, metadata}` items). No new tables, routes, pages, or nav code.

**Storage** (migration `0002_platform_feeds.sql`):
- `platform_connections` — per-user credentials (JSON, write-only via the API: responses only reveal *which* fields are set), enabled flag, `last_synced_at` / `last_error`
- `platform_items` — normalised synced items, deduped by `(user, platform, external_id)`, with a nullable `bookmark_id` link

**Sync**:
- Cron trigger (`17 */6 * * *`) added to `wrangler.jsonc`; the new `scheduled` handler syncs every enabled connection and records failures on the connection rather than aborting the batch
- Manual “Sync now” via `POST /api/platforms/:platform/sync`
- Inserts use `ON CONFLICT DO NOTHING`, so re-syncs are cheap and idempotent

**API**: `GET/PUT/PATCH/DELETE /api/platforms[/:platform]`, `GET /api/platform-items?platform=…` (same paginated envelope as tweets/toots), `POST /api/platform-items/:id/bookmark` — one-click conversion that creates a bookmark (tagged with the platform, `video` type for YouTube) and remembers the link so the button flips to “Bookmarked”.

**UI**:
- One generic route `/platform/$platform` renders any platform’s feed through the existing `Feed` component via a new `PlatformItemCard` (author header for social posts, thumbnail for repos/videos, add-bookmark action)
- Sidebar entries appear automatically (with counts from `/api/meta`) once a platform has items
- Settings → Integrations gets a “Platform feeds” section: connect / pause / resume / sync now / remove per platform, masked saved secrets with “Change”, last-sync time and last error surfaced

## Platform notes

- **Bluesky** — handle + app password → `com.atproto.server.createSession` → `app.bsky.bookmark.getBookmarks`
- **GitHub** — PAT → `GET /user/starred` with the `star+json` media type so `starred_at` is the item date
- **YouTube** — liked videos require OAuth (no API-key route), so the connection takes client id/secret + refresh token and exchanges per sync

## Notes & follow-ups

- Existing `tweets`/`toots` tables, routes, and pages are untouched; they could later be folded into this system (register `twitter`/`mastodon` in the catalog and backfill `platform_items`), at which point their bespoke code can be deleted
- The existing Bluesky **cross-posting** integration is unchanged and now lives under its own heading in settings
- Credentials are stored like the existing `user_integrations.bluesky_app_password` (plaintext in Postgres) — encryption-at-rest would be a separate change
- Verified: `tsc -b` clean, `pnpm vitest run` 26/26 passing (11 new tests for the fetcher mappers), biome clean on the new files

https://claude.ai/code/session_01MGgu9Zun8cvBv1hy2tvgu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGgu9Zun8cvBv1hy2tvgu3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds platform-agnostic feeds that sync external saves into Otter (Bluesky bookmarks, GitHub stars, YouTube likes). Includes per-user connections, background/manual sync, a paginated items API, and a generic feed/UI so new platforms are config + one fetcher.

- **New Features**
  - Shared catalog `src/platforms/catalog.ts` drives settings forms, feed titles/icons, sidebar, and maps to worker fetchers (add a platform = one catalog entry + one fetcher).
  - Storage: `platform_connections` (credentials, enabled, last sync/error) and `platform_items` (normalized items, deduped per user/platform/external_id, optional `bookmark_id`).
  - Sync: 6-hour cron in `wrangler.jsonc` plus “Sync now” (`POST /api/platforms/:platform/sync`); inserts are idempotent and errors are recorded per-connection.
  - API: `GET/PUT/PATCH/DELETE /api/platforms[/:platform]`, `GET /api/platform-items?platform=…` (paginated), `POST /api/platform-items/:id/bookmark` (creates a bookmark and links it).
  - UI: Generic `/platform/$platform` feed via `PlatformItemCard`, auto sidebar entries with counts from `/api/meta`, and Settings → Integrations → “Platform feeds” (connect/pause/resume/sync/remove, masked secrets, last sync/error).
  - Fetchers: Bluesky (`com.atproto.server.createSession`, `app.bsky.bookmark.getBookmarks`), GitHub (`GET /user/starred` with `star+json`), YouTube (OAuth refresh token → liked videos).

<sup>Written for commit c8d5d9c7c4a8da491b535d14695e09aa545915db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/Otter/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

